### PR TITLE
chore: change login btn redirect

### DIFF
--- a/src/components/AppBar/AppBar.tsx
+++ b/src/components/AppBar/AppBar.tsx
@@ -18,7 +18,7 @@ export default function AppBar() {
   const {logout, isAuthenticated, user} = useAuth();
   const handleLogout = () => logout();
   
-  const handleLogin = () => navigate('/login');
+  const handleLogin = () => navigate('/auth');
   const [menuOpen, toggleMenu] = useToggle(false);
   return (
     <nav className="sticky top-0 z-50 bg-white shadow-md">


### PR DESCRIPTION
This pull request includes a small change to the `AppBar` component. The change modifies the login navigation path.

* [`src/components/AppBar/AppBar.tsx`](diffhunk://#diff-9854d0062357cc6c7ee3697de28715b8fa80a6550b7191655ca770d96796fdf1L21-R21): Changed the `handleLogin` function to navigate to `/auth` instead of `/login`.