### PR TITLE
fix: update API endpoint for creating preferences to use plural form

### DIFF
--- a/src/services/Preference.ts
+++ b/src/services/Preference.ts
@@ -20,7 +20,7 @@ interface PostPreferenceResponse {
 
 export const createOnePreference = async (order_id: string) => {
   const response = await axios.post<ResponseDataTyped<PostPreferenceResponse>>(
-    `${apiBaseUrl}/preference`,
+    `${apiBaseUrl}/preferences`,
     {order_id},
     getAuthConfig()
   );


### PR DESCRIPTION
## ¿Qué tipo de PR es este?

- [ ] Refactorización
- [ ] Funcionalidad
- [x] Corrección de error
- [ ] Optimización
- [ ] Actualización de documentación

## Descripción
This pull request includes a small but important change to the `createOnePreference` function in the `src/services/Preference.ts` file. The change updates the URL endpoint from `/preference` to `/preferences` to align with the correct API endpoint.

* [`src/services/Preference.ts`](diffhunk://#diff-1d4a6c429bd805cdbc1dadb0a95bbfe9ff86c5cc86f5b782799db2f6ddf84bb4L23-R23): Updated the URL endpoint in the `createOnePreference` function from `/preference` to `/preferences`.