### PR TITLE
Muvi 143

### DIFF
--- a/src/features/admin/components/MuseumForm.tsx
+++ b/src/features/admin/components/MuseumForm.tsx
@@ -1,6 +1,11 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import * as z from "zod";
+import { useCallback, useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { Loader2, SquareArrowOutUpRight } from "lucide-react";
+
+// Components
 import {
   Dialog,
   DialogContent,
@@ -20,8 +25,6 @@ import {
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
-import { DialogDescription } from "@radix-ui/react-dialog";
-import ImageUpload from "@/shared/components/ImageUpload";
 import {
   Select,
   SelectContent,
@@ -29,12 +32,19 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { useCallback, useEffect, useState } from "react";
-import { getMuseumTours } from "@/services/Museums";
-import { Tour } from "@/shared/types/Tour";
-import { Link } from "react-router-dom";
-import { SquareArrowOutUpRight } from "lucide-react";
+import ImageUpload from "@/shared/components/ImageUpload";
 
+// Services
+import { getMuseumTours } from "@/services/Museums";
+import { uploadImage } from "@/services/upload";
+
+// Hooks
+import { useToast } from "@/hooks/use-toast";
+
+// Types
+import { Tour } from "@/shared/types/Tour";
+
+// Schema
 const formSchema = z.object({
   name: z.string().min(2, "El nombre debe tener al menos 2 caracteres"),
   description: z
@@ -44,13 +54,15 @@ const formSchema = z.object({
     .string()
     .min(5, "La dirección debe tener al menos 5 caracteres"),
   main_tour_id: z.string().uuid().optional().nullable(),
-  main_photo: z.string(),
+  main_photo: z.string().min(1, "La imagen es requerida"),
 });
+
+type FormValues = z.infer<typeof formSchema>;
 
 interface MuseumFormProps {
   isOpen: boolean;
   onClose: () => void;
-  onSubmit: (data: z.infer<typeof formSchema>) => void;
+  onSubmit: (data: FormValues) => void;
   initialValues?: {
     id?: string;
     name: string;
@@ -62,16 +74,22 @@ interface MuseumFormProps {
     updated_at?: string;
   };
 }
+
 const MuseumForm = ({
   isOpen,
   onClose,
   onSubmit,
   initialValues,
 }: MuseumFormProps) => {
+  // States
   const [museumTours, setMuseumTours] = useState<Tour[]>([]);
+  const [isUploading, setIsUploading] = useState(false);
 
-  // ---- Form ----
-  const form = useForm<z.infer<typeof formSchema>>({
+  // Hooks
+  const { toast } = useToast();
+
+  // Form
+  const form = useForm<FormValues>({
     resolver: zodResolver(formSchema),
     defaultValues: {
       name: initialValues?.name || "",
@@ -82,20 +100,16 @@ const MuseumForm = ({
     },
   });
 
-  const handleSubmit = (values: z.infer<typeof formSchema>) => {
-    onSubmit(values);
-    form.reset();
-    onClose();
-  };
-
-  // ---- fetch museum tours ----
+  // Effects
   const fetchMuseumTours = useCallback(async () => {
     if (!initialValues?.id) return;
     try {
-      const tours = await getMuseumTours(initialValues.id);
-      setMuseumTours(tours.data);
+      const response = await getMuseumTours(initialValues.id);
+      if (response.ok) {
+        setMuseumTours(response.data);
+      }
     } catch (error) {
-      console.error(error);
+      console.error("Error fetching museum tours:", error);
       setMuseumTours([]);
     }
   }, [initialValues?.id]);
@@ -104,24 +118,57 @@ const MuseumForm = ({
     fetchMuseumTours();
   }, [fetchMuseumTours]);
 
+  // Handlers
+  const handleSubmit = async (values: FormValues) => {
+    setIsUploading(true);
+
+    try {
+      // Si la imagen es base64, súbela a Cloudinary
+      let finalImageUrl = values.main_photo;
+      if (values.main_photo.startsWith("data:image")) {
+        const response = await uploadImage(values.main_photo);
+        if (!response.ok || !response.data?.url) {
+          throw new Error("Error al subir la imagen");
+        }
+        finalImageUrl = response.data.url;
+      }
+
+      // Envía el formulario con la URL de Cloudinary
+      const formattedValues = {
+        ...values,
+        main_photo: finalImageUrl,
+      };
+
+      await onSubmit(formattedValues);
+      form.reset();
+      onClose();
+    } catch (error) {
+      toast({
+        title: "Error al guardar",
+        description:
+          "Ocurrió un error al guardar los cambios. Por favor, intenta de nuevo.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent
-        className="sm:max-w-[600px p-6] font-inter"
+        className="sm:max-w-[600px] p-6 font-inter"
         aria-describedby="dialog-description"
       >
         <DialogHeader className="space-y-3 pb-4 border-b">
           <DialogTitle className="text-2xl font-semibold tracking-tight">
             {initialValues ? "Editar museo" : "Crear nuevo museo"}
           </DialogTitle>
-          <DialogDescription
-            className="text-base text-gray-500"
-            id="dialog-description"
-          >
+          <p className="text-base text-gray-500" id="dialog-description">
             {initialValues
               ? "Edite la información del museo seleccionado"
               : "Complete los campos para agregar un nuevo museo al sistema."}
-          </DialogDescription>
+          </p>
         </DialogHeader>
 
         <Form {...form}>
@@ -129,6 +176,7 @@ const MuseumForm = ({
             onSubmit={form.handleSubmit(handleSubmit)}
             className="space-y-6"
           >
+            {/* Name */}
             <FormField
               control={form.control}
               name="name"
@@ -143,6 +191,7 @@ const MuseumForm = ({
               )}
             />
 
+            {/* Description */}
             <FormField
               control={form.control}
               name="description"
@@ -161,6 +210,7 @@ const MuseumForm = ({
               )}
             />
 
+            {/* Address */}
             <FormField
               control={form.control}
               name="address_name"
@@ -175,6 +225,7 @@ const MuseumForm = ({
               )}
             />
 
+            {/* Main Tour Selection - Only shown when editing */}
             {initialValues && (
               <FormField
                 control={form.control}
@@ -223,6 +274,7 @@ const MuseumForm = ({
               />
             )}
 
+            {/* Image Upload */}
             <FormField
               control={form.control}
               name="main_photo"
@@ -242,12 +294,29 @@ const MuseumForm = ({
               )}
             />
 
+            {/* Form Actions */}
             <DialogFooter>
-              <Button type="button" variant="outline" onClick={onClose}>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={onClose}
+                disabled={isUploading}
+              >
                 Cancelar
               </Button>
-              <Button type="submit" className="text-white">
-                Guardar
+              <Button
+                type="submit"
+                className="text-white"
+                disabled={isUploading}
+              >
+                {isUploading ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Procesando...
+                  </>
+                ) : (
+                  "Guardar"
+                )}
               </Button>
             </DialogFooter>
           </form>

--- a/src/features/admin/components/TourForm.tsx
+++ b/src/features/admin/components/TourForm.tsx
@@ -2,6 +2,10 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import * as z from "zod";
 import { useEffect, useState } from "react";
+import { Loader2 } from "lucide-react";
+import { FaTags } from "react-icons/fa";
+
+// Components
 import {
   Dialog,
   DialogContent,
@@ -20,17 +24,23 @@ import {
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
-import { DialogDescription } from "@radix-ui/react-dialog";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Museum } from "@/types/Museums";
-import { getAllMuseums } from "@/services/Museums";
-import { ChevronDown } from "lucide-react";
 import ImageUpload from "@/shared/components/ImageUpload";
-
-import { FaTags } from "react-icons/fa";
 import { TagManager } from "./TagManager";
+import { CustomSelect } from "@/shared/components/CustomSelect";
+
+// Services
+import { getAllMuseums } from "@/services/Museums";
+import { uploadImage } from "@/services/upload";
+
+// Hooks
+import { useToast } from "@/hooks/use-toast";
+
+// Types
+import { Museum } from "@/types/Museums";
 import { Tag } from "@/types/tag";
 
+// Schema
 const formSchema = z.object({
   name: z.string().min(2, "El nombre debe tener al menos 2 caracteres"),
   description: z
@@ -51,51 +61,14 @@ const formSchema = z.object({
   ),
 });
 
+type FormValues = z.infer<typeof formSchema>;
+
 interface TourFormProps {
   isOpen: boolean;
   onClose: () => void;
-  onSubmit: (
-    data: Omit<z.infer<typeof formSchema>, "tags"> & { tags: string[] }
-  ) => void;
-  initialValues?: Partial<z.infer<typeof formSchema>>;
+  onSubmit: (data: Omit<FormValues, "tags"> & { tags: string[] }) => void;
+  initialValues?: Partial<FormValues>;
 }
-
-const CustomSelect = ({
-  value,
-  onChange,
-  options,
-  placeholder,
-  error,
-}: {
-  value: string;
-  onChange: (value: string) => void;
-  options: Museum[];
-  placeholder: string;
-  error?: boolean;
-}) => {
-  return (
-    <div className="relative">
-      <select
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        className={`w-full h-10 px-3 rounded-md border bg-background text-sm outline-none 
-            focus:outline-none focus:ring-2 focus:ring-ring focus:border-input 
-            disabled:cursor-not-allowed disabled:opacity-50 appearance-none
-            ${error ? "border-destructive" : "border-input"}`}
-      >
-        <option value="" disabled>
-          {placeholder}
-        </option>
-        {options.map((option) => (
-          <option key={option.id} value={option.id}>
-            {option.name}
-          </option>
-        ))}
-      </select>
-      <ChevronDown className="absolute right-3 top-1/2 transform -translate-y-1/2 h-4 w-4 pointer-events-none text-muted-foreground" />
-    </div>
-  );
-};
 
 const TourForm = ({
   isOpen,
@@ -103,12 +76,33 @@ const TourForm = ({
   onSubmit,
   initialValues,
 }: TourFormProps) => {
+  // States
   const [museums, setMuseums] = useState<Museum[]>([]);
   const [showTagManager, setShowTagManager] = useState(false);
   const [selectedTags, setSelectedTags] = useState<Tag[]>(
     initialValues?.tags || []
   );
+  const [isUploading, setIsUploading] = useState(false);
 
+  // Hooks
+  const { toast } = useToast();
+
+  // Form
+  const form = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      name: initialValues?.name || "",
+      description: initialValues?.description || "",
+      price: initialValues?.price || "",
+      stars: initialValues?.stars || 0,
+      url: initialValues?.url || "",
+      image_url: initialValues?.image_url || "",
+      museum_id: initialValues?.museum_id || "",
+      tags: initialValues?.tags || [],
+    },
+  });
+
+  // Effects
   useEffect(() => {
     const fetchMuseums = async () => {
       try {
@@ -124,28 +118,47 @@ const TourForm = ({
     fetchMuseums();
   }, []);
 
-  const form = useForm<z.infer<typeof formSchema>>({
-    resolver: zodResolver(formSchema),
-    defaultValues: initialValues || {
-      name: "",
-      description: "",
-      price: "",
-      stars: 0,
-      url: "",
-      image_url: "",
-      museum_id: "",
-    },
-  });
+  // Handlers
+  const handleSubmit = async (values: FormValues) => {
+    setIsUploading(true);
 
-  const handleSubmit = (values: z.infer<typeof formSchema>) => {
-    const formattedValues = {
-      ...values,
-      tags: values.tags.map((tag) => tag.id), // Solo enviamos los IDs
-    };
+    try {
+      // Si la imagen es base64, súbela a Cloudinary
+      let finalImageUrl = values.image_url;
+      if (values.image_url.startsWith("data:image")) {
+        const response = await uploadImage(values.image_url);
+        if (!response.ok || !response.data?.url) {
+          throw new Error("Error al subir la imagen");
+        }
+        finalImageUrl = response.data.url;
+      }
 
-    onSubmit(formattedValues);
-    form.reset();
-    onClose();
+      // Envía el formulario con la URL de Cloudinary
+      const formattedValues = {
+        ...values,
+        image_url: finalImageUrl,
+        tags: values.tags.map((tag) => tag.id),
+      };
+
+      await onSubmit(formattedValues);
+      form.reset();
+      onClose();
+    } catch (error) {
+      toast({
+        title: "Error al guardar",
+        description:
+          "Ocurrió un error al guardar los cambios. Por favor, intenta de nuevo.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const handleTagsSave = (tags: Tag[]) => {
+    setSelectedTags(tags);
+    setShowTagManager(false);
+    form.setValue("tags", tags);
   };
 
   return (
@@ -157,11 +170,11 @@ const TourForm = ({
               <DialogTitle className="text-2xl font-semibold tracking-tight">
                 {initialValues ? "Editar tour" : "Crear nuevo tour"}
               </DialogTitle>
-              <DialogDescription className="text-base text-gray-500">
+              <p className="text-base text-gray-500">
                 {initialValues
                   ? "Edite la información del tour seleccionado"
                   : "Complete los campos para agregar un nuevo tour al sistema."}
-              </DialogDescription>
+              </p>
             </DialogHeader>
 
             <Form {...form}>
@@ -169,6 +182,7 @@ const TourForm = ({
                 onSubmit={form.handleSubmit(handleSubmit)}
                 className="space-y-6 pt-4"
               >
+                {/* Museum Select */}
                 <FormField
                   control={form.control}
                   name="museum_id"
@@ -189,6 +203,7 @@ const TourForm = ({
                   )}
                 />
 
+                {/* Tour Name */}
                 <FormField
                   control={form.control}
                   name="name"
@@ -203,6 +218,7 @@ const TourForm = ({
                   )}
                 />
 
+                {/* Description */}
                 <FormField
                   control={form.control}
                   name="description"
@@ -221,6 +237,7 @@ const TourForm = ({
                   )}
                 />
 
+                {/* Price */}
                 <FormField
                   control={form.control}
                   name="price"
@@ -240,6 +257,7 @@ const TourForm = ({
                   )}
                 />
 
+                {/* URL */}
                 <FormField
                   control={form.control}
                   name="url"
@@ -257,6 +275,7 @@ const TourForm = ({
                   )}
                 />
 
+                {/* Tags */}
                 <FormField
                   name="tags"
                   render={() => (
@@ -275,6 +294,7 @@ const TourForm = ({
                   )}
                 />
 
+                {/* Image Upload */}
                 <FormField
                   control={form.control}
                   name="image_url"
@@ -294,26 +314,39 @@ const TourForm = ({
                   )}
                 />
 
+                {/* Tag Manager Dialog */}
                 {showTagManager && (
                   <TagManager
                     isOpen={showTagManager}
                     onClose={() => setShowTagManager(false)}
                     selectedTags={selectedTags}
-                    onSave={(tags) => {
-                      setSelectedTags(tags);
-                      setShowTagManager(false);
-                      // Asegúrate de incluir los tags en el formulario
-                      form.setValue("tags", tags);
-                    }}
+                    onSave={handleTagsSave}
                   />
                 )}
 
+                {/* Form Actions */}
                 <DialogFooter className="pt-6">
-                  <Button type="button" variant="outline" onClick={onClose}>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={onClose}
+                    disabled={isUploading}
+                  >
                     Cancelar
                   </Button>
-                  <Button type="submit" className="text-white">
-                    Guardar
+                  <Button
+                    type="submit"
+                    className="text-white"
+                    disabled={isUploading}
+                  >
+                    {isUploading ? (
+                      <>
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        Procesando...
+                      </>
+                    ) : (
+                      "Guardar"
+                    )}
                   </Button>
                 </DialogFooter>
               </form>

--- a/src/services/upload.ts
+++ b/src/services/upload.ts
@@ -1,0 +1,24 @@
+import type ResponseData from "@/types/ResponseData";
+
+export const uploadImage = async (file: string): Promise<ResponseData> => {
+  const base64Response = await fetch(file);
+  const blob = await base64Response.blob();
+
+  const formData = new FormData();
+  formData.append("image", blob);
+
+  const response = await fetch(
+    `${import.meta.env.VITE_API_BASE_URL}/storage/upload`,
+    {
+      method: "POST",
+      body: formData,
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+
+  const data = await response.json();
+  return data;
+};

--- a/src/shared/components/CustomSelect.tsx
+++ b/src/shared/components/CustomSelect.tsx
@@ -1,0 +1,41 @@
+import { ChevronDown } from "lucide-react";
+import { Museum } from "@/types/Museums";
+
+interface CustomSelectProps {
+  value: string;
+  onChange: (value: string) => void;
+  options: Museum[];
+  placeholder: string;
+  error?: boolean;
+}
+
+export const CustomSelect = ({
+  value,
+  onChange,
+  options,
+  placeholder,
+  error,
+}: CustomSelectProps) => {
+  return (
+    <div className="relative">
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className={`w-full h-10 px-3 rounded-md border bg-background text-sm outline-none 
+            focus:outline-none focus:ring-2 focus:ring-ring focus:border-input 
+            disabled:cursor-not-allowed disabled:opacity-50 appearance-none
+            ${error ? "border-destructive" : "border-input"}`}
+      >
+        <option value="" disabled>
+          {placeholder}
+        </option>
+        {options.map((option) => (
+          <option key={option.id} value={option.id}>
+            {option.name}
+          </option>
+        ))}
+      </select>
+      <ChevronDown className="absolute right-3 top-1/2 transform -translate-y-1/2 h-4 w-4 pointer-events-none text-muted-foreground" />
+    </div>
+  );
+};

--- a/src/shared/components/ImageUpload.tsx
+++ b/src/shared/components/ImageUpload.tsx
@@ -1,51 +1,84 @@
 import { X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
+import { useRef } from "react";
 
-const MAX_FILE_SIZE_MB = 5; // 5MB máximo
+const MAX_FILE_SIZE_MB = 5;
 const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 * 1024;
 
-const ImageUpload = ({
-  value,
-  onChange,
-  onClear,
-  error,
-}: {
+interface ImageUploadProps {
   value: string;
   onChange: (value: string) => void;
   onClear: () => void;
   error?: boolean;
-}) => {
-  const { toast } = useToast();
+}
 
-  const handleImageUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
+const ImageUpload = ({ value, onChange, onClear, error }: ImageUploadProps) => {
+  const { toast } = useToast();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleImageUpload = async (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
     const file = event.target.files?.[0];
 
-    if (file) {
-      // Validar tamaño de archivo
-      if (file.size > MAX_FILE_SIZE_BYTES) {
-        console.log(
-          `Imagen demasiado grande: ${(file.size / 1024 / 1024).toFixed(2)}MB`
-        );
+    if (!file) {
+      return;
+    }
+
+    if (file.size > MAX_FILE_SIZE_BYTES) {
+      toast({
+        title: "Error al subir imagen",
+        description: `La imagen es demasiado grande. El tamaño máximo permitido es ${MAX_FILE_SIZE_MB}MB. Tu imagen tiene ${(
+          file.size /
+          1024 /
+          1024
+        ).toFixed(2)}MB.`,
+        variant: "destructive",
+      });
+      event.target.value = "";
+      return;
+    }
+
+    try {
+      const reader = new FileReader();
+
+      reader.onloadend = () => {
+        const base64 = reader.result as string;
+        onChange(base64);
+      };
+
+      reader.onerror = () => {
         toast({
-          title: "Error al subir imagen",
-          description: `La imagen es demasiado grande. El tamaño máximo permitido es ${MAX_FILE_SIZE_MB}MB. Tu imagen tiene ${(
-            file.size /
-            1024 /
-            1024
-          ).toFixed(2)}MB.`,
+          title: "Error al procesar imagen",
+          description:
+            "No se pudo leer el archivo. Por favor, intenta de nuevo.",
           variant: "destructive",
         });
-        event.target.value = ""; // Limpiar input
-        return;
-      }
-
-      const reader = new FileReader();
-      reader.onloadend = () => {
-        onChange(reader.result as string);
+        if (inputRef.current) {
+          inputRef.current.value = "";
+        }
       };
+
       reader.readAsDataURL(file);
+    } catch (error) {
+      toast({
+        title: "Error al procesar imagen",
+        description:
+          "Ocurrió un error al procesar la imagen. Por favor, intenta de nuevo.",
+        variant: "destructive",
+      });
+      if (inputRef.current) {
+        inputRef.current.value = "";
+      }
     }
+  };
+
+  const handleClear = () => {
+    if (inputRef.current) {
+      inputRef.current.value = "";
+    }
+    onClear();
   };
 
   return (
@@ -55,7 +88,7 @@ const ImageUpload = ({
           type="button"
           variant="outline"
           className={error ? "border-destructive" : ""}
-          onClick={() => document.getElementById("image-upload")?.click()}
+          onClick={() => inputRef.current?.click()}
         >
           Subir imagen
         </Button>
@@ -63,7 +96,7 @@ const ImageUpload = ({
           Tamaño máximo: {MAX_FILE_SIZE_MB}MB
         </span>
         <input
-          id="image-upload"
+          ref={inputRef}
           type="file"
           className="hidden"
           accept="image/*"
@@ -78,7 +111,7 @@ const ImageUpload = ({
             variant="destructive"
             size="icon"
             className="absolute -right-2 -top-2 h-6 w-6 rounded-full"
-            onClick={onClear}
+            onClick={handleClear}
           >
             <X className="h-4 w-4" />
           </Button>


### PR DESCRIPTION
## ¿Qué tipo de PR es este?

- [x] Refactorización
- [ ] Funcionalidad
- [ ] Corrección de error
- [x] Optimización
- [ ] Actualización de documentación

## Descripción
Se implementó la carga de imágenes con Cloudinary para los formularios de Tours y Museos. Las imágenes se mantienen en base64 localmente hasta que el usuario confirma el formulario, momento en el cual se suben a Cloudinary.

NO HUBO CAMBIOS EN BACK (dev), la logica implementada ahi si jala.

Cambios principales:
- Subida de imagenes a Cloudinary hasta el guardado del formulario
- Refactorizados TourForm y MuseumForm para mejor manejo de estados
- Agregado servicio dedicado para uploads
- Mejorado el manejo de errores y UX durante la carga

## Recursos útiles
...

## Pruebas
1. Ir a la sección de Tours o Museos
2. Click en "Crear nuevo"
3. Seleccionar una imagen
4. Verificar que la imagen se previsualiza sin subirse a Cloudinary
5. Llenar el resto del formulario
6. Click en "Guardar"
7. Verificar que la imagen se sube y el formulario se guarda correctamente
8. Verificar que el botón de guardar se deshabilita durante la carga
9. Probar cancelar el formulario y verificar que la imagen no se subió a Cloudinary

## Capturas de pantalla

La UI se mantuvo igual, la imagen pasa a base64 antes de ser enviada al servicio:

![image](https://github.com/user-attachments/assets/8a454c61-8b8a-4e58-899b-79e39b76ca9a)

Al momento de "Guardar", ahi es cuando se manda a cloudinary y el boton cambia a "Procesando":

![image](https://github.com/user-attachments/assets/c9ad170a-666a-4fad-af3c-a6a27e354db1)

y como se puede apreciar, en la API se guardo la imagen correctamente en cloudinary:

![image](https://github.com/user-attachments/assets/fbb50c71-3214-48d9-8f39-f53eb75f3ed6)