### PR TITLE
Muvi 160 front gestor de landing en admin

### DIFF
--- a/src/components/NewsCarousel/CarouselSlide.tsx
+++ b/src/components/NewsCarousel/CarouselSlide.tsx
@@ -1,3 +1,4 @@
+// src/components/NewsCarousel/CarouselSlide.tsx
 import React from "react";
 import { CarouselSlideProps } from "./slide-data";
 
@@ -10,15 +11,23 @@ const CarouselSlide: React.FC<CarouselSlideProps> = ({
     <div className="relative h-full">
       <img
         src={imageUrl}
-        alt="Background"
+        alt={title || "Slide background"}
         className="absolute inset-0 object-cover w-full h-full blur-sm"
+        onError={(e) => {
+          // Manejar errores de carga de imagen
+          const target = e.target as HTMLImageElement;
+          target.src =
+            "https://placehold.co/1200x800/111/fff?text=Imagen+no+disponible";
+        }}
       />
       <div className="absolute inset-0 bg-black opacity-55"></div>
       <div className="relative z-10 flex flex-col items-start justify-center h-full p-4 text-white sm:p-8 md:p-12">
         <div className="flex flex-col max-w-xl">
-          <p className="mb-2 text-sm sm:text-base md:text-lg">{title}</p>
+          <p className="mb-2 text-sm sm:text-base md:text-lg uppercase">
+            {title || ""}
+          </p>
           <h1 className="mb-4 text-2xl sm:text-3xl md:text-4xl sm:mb-6">
-            {description}
+            {description || ""}
           </h1>
           <div className="flex space-x-4">
             <button className="px-4 py-2 text-sm text-black transition duration-200 bg-white bg-opacity-75 rounded-lg hover:bg-opacity-100 sm:text-base">

--- a/src/components/NewsCarousel/NewsCarousel.tsx
+++ b/src/components/NewsCarousel/NewsCarousel.tsx
@@ -1,31 +1,82 @@
-import React, { useState, useEffect, useCallback } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
-import { wrap } from 'popmotion';
-import CarouselSlide from './CarouselSlide';
-import { slides } from './slide-data';
-import { variants, swipeConfidenceThreshold, swipePower } from './animations';
-import SocialMediaIcons from '../SocialMediaIcons/SocialMediaIcons';
+// src/components/NewsCarousel/NewsCarousel.tsx
+import React, { useState, useEffect, useCallback } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { wrap } from "popmotion";
+import CarouselSlide from "./CarouselSlide";
+import { variants, swipeConfidenceThreshold, swipePower } from "./animations";
+import SocialMediaIcons from "../SocialMediaIcons/SocialMediaIcons";
+import { getMainCarousel } from "@/services/Carousel";
+import CarouselSlideInterface from "./slide-data";
 
 const NewsCarousel: React.FC = () => {
+  const [slides, setSlides] = useState<CarouselSlideInterface[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
   const [[page, direction], setPage] = useState([0, 0]);
 
-  const imageIndex = wrap(0, slides.length, page);
+  const imageIndex = wrap(0, Math.max(slides.length, 1), page);
 
-  const paginate = useCallback((newDirection: number) => {
-    setPage((prevPage) => [prevPage[0] + newDirection, newDirection]);
-  }, [setPage]);
+  const fetchCarouselData = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const response = await getMainCarousel();
+      if (response.ok && response.data && response.data.slides) {
+        // Convertir los datos de la API al formato que espera el componente
+        const formattedSlides = response.data.slides.map((slide) => ({
+          id: slide.id || slide.index,
+          title: slide.title || "",
+          description: slide.description || "",
+          imageUrl: slide.image_url || "",
+        }));
+        setSlides(formattedSlides);
+      }
+    } catch (error) {
+      console.error("Error loading carousel data:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
 
   useEffect(() => {
+    fetchCarouselData();
+  }, [fetchCarouselData]);
+
+  const paginate = useCallback(
+    (newDirection: number) => {
+      setPage((prevPage) => [prevPage[0] + newDirection, newDirection]);
+    },
+    [setPage]
+  );
+
+  useEffect(() => {
+    if (slides.length < 1) return;
+
     const interval = setInterval(() => {
       paginate(1);
     }, 7000);
 
     return () => clearInterval(interval);
-  }, [paginate]);
+  }, [paginate, slides.length]);
 
   const handleSlideChange = (index: number) => {
     setPage([index, 0]);
   };
+
+  // Mostrar estado de carga o fallback si no hay slides
+  if (isLoading) {
+    return (
+      <div className="bg-black relative h-[calc(100vh-5rem)] flex items-center justify-center">
+        <div className="text-white">Cargando...</div>
+      </div>
+    );
+  }
+
+  if (slides.length === 0) {
+    return (
+      <div className="bg-black relative h-[calc(100vh-5rem)] flex items-center justify-center">
+        <div className="text-white">No hay slides disponibles</div>
+      </div>
+    );
+  }
 
   return (
     <div className="bg-black relative h-[calc(100vh-5rem)] overflow-hidden">
@@ -38,17 +89,19 @@ const NewsCarousel: React.FC = () => {
             initial="enter"
             animate={index === imageIndex ? "center" : "exit"}
             exit="exit"
-            className={`absolute inset-0 ${index === imageIndex ? 'z-10' : 'z-0 pointer-events-none'}`}
+            className={`absolute inset-0 ${
+              index === imageIndex ? "z-10" : "z-0 pointer-events-none"
+            }`}
             transition={{
               x: { type: "spring", stiffness: 300, damping: 30 },
-              opacity: { duration: 0.5 }
+              opacity: { duration: 0.5 },
             }}
             drag="x"
             dragConstraints={{ left: 0, right: 0 }}
             dragElastic={1}
             onDragEnd={(_, { offset, velocity }) => {
               const swipe = swipePower(offset.x, velocity.x);
-              
+
               if (swipe < -swipeConfidenceThreshold) {
                 paginate(1);
               } else if (swipe > swipeConfidenceThreshold) {
@@ -68,16 +121,18 @@ const NewsCarousel: React.FC = () => {
       <div className="z-30 absolute bottom-4 sm:bottom-8 right-4 sm:right-8 md:right-40 flex space-x-2 sm:space-x-8">
         {slides.map((_, index) => (
           <button
-            key={slides[index].id}
+            key={index}
             onClick={() => handleSlideChange(index)}
-            className={`text-white ${imageIndex === index ? 'font-bold' : 'text-gray-300'} w-6 h-6 text-xs sm:text-sm`}
+            className={`text-white ${
+              imageIndex === index ? "font-bold" : "text-gray-300"
+            } w-6 h-6 text-xs sm:text-sm`}
           >
             {index + 1}
           </button>
         ))}
       </div>
-      <SocialMediaIcons 
-        containerClass="z-30 p-1 bg-black rounded-xl bg-opacity-65 absolute right-2 sm:right-4 top-1/2 transform -translate-y-1/2 space-y-2 text-white hidden sm:block" 
+      <SocialMediaIcons
+        containerClass="z-30 p-1 bg-black rounded-xl bg-opacity-65 absolute right-2 sm:right-4 top-1/2 transform -translate-y-1/2 space-y-2 text-white hidden sm:block"
         iconClass="text-xl sm:text-2xl md:text-3xl"
       />
     </div>

--- a/src/components/NewsCarousel/slide-data.ts
+++ b/src/components/NewsCarousel/slide-data.ts
@@ -1,35 +1,9 @@
-import Background1 from '@/assets/images/background-1.webp';
-import Background2 from '@/assets/images/background-2.webp';
-import Background3 from '@/assets/images/background-3.webp';
-
 export interface CarouselSlideProps {
-    title: string;
-    description: string;
-    imageUrl: string;
-  }
-  
-  export default interface CarouselSlideInterface extends CarouselSlideProps {
-    id: number;
-  }
-  
-  export const slides: CarouselSlideInterface[] = [
-    {
-      id: 1,
-      title: 'CONOCE MUVI',
-      description: 'MUVi está listo para ofrecerte las mejores experiencias en Recorridos Virtuales',
-      imageUrl: Background1,
-    },
-    {
-      id: 2,
-      title: 'CONOCE MUVI',
-      description: 'Hacemos del arte una experiencia cercana para ti.',
-      imageUrl: Background2,
-    },
-    {
-      id: 3,
-      title: 'CONOCE MUVI',
-      description: 'Descubre nuestros recorridos y elige tu favorito.',
-      imageUrl: Background3,
-    }
-  ];
-  
+  title: string;
+  description: string;
+  imageUrl: string;
+}
+
+export default interface CarouselSlideInterface extends CarouselSlideProps {
+  id: number | string; // Cambiar a number | string para soportar UUIDs
+}

--- a/src/features/admin/components/CarouselForm.tsx
+++ b/src/features/admin/components/CarouselForm.tsx
@@ -1,0 +1,416 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useFieldArray, useForm } from "react-hook-form";
+import * as z from "zod";
+import { useState } from "react";
+import { Loader2, Plus, Trash2, Check, X } from "lucide-react";
+
+// Components
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import ImageUpload from "@/shared/components/ImageUpload";
+
+// Services
+import { uploadImage } from "@/services/upload";
+
+// Hooks
+import { useToast } from "@/hooks/use-toast";
+
+// Types
+import { Carousel, CarouselFormData } from "@/shared/types/Carousel";
+
+const slideSchema = z.object({
+  index: z.number(),
+  image_url: z.string().min(1, "La imagen es requerida"),
+  title: z.string().min(1, "El título es requerido"),
+  description: z.string().min(1, "La descripción es requerida"),
+});
+
+const formSchema = z.object({
+  name: z.string().min(2, "El nombre debe tener al menos 2 caracteres"),
+  description: z
+    .string()
+    .min(10, "La descripción debe tener al menos 10 caracteres"),
+  slides: z.array(slideSchema).min(1, "Debe haber al menos un slide"),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+interface CarouselFormProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (data: CarouselFormData) => void;
+  initialValues?: Carousel;
+}
+
+const CarouselForm = ({
+  isOpen,
+  onClose,
+  onSubmit,
+  initialValues,
+}: CarouselFormProps) => {
+  // Estados
+  const [isUploading, setIsUploading] = useState(false);
+  const [slideConfirmingDelete, setSlideConfirmingDelete] = useState<
+    number | null
+  >(null);
+
+  // Hooks
+  const { toast } = useToast();
+
+  // Formulario
+  const form = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      name: initialValues?.name || "",
+      description: initialValues?.description || "",
+      slides: initialValues?.slides.map((slide) => ({
+        index: slide.index,
+        image_url: slide.image_url,
+        title: slide.title,
+        description: slide.description,
+      })) || [{ index: 0, image_url: "", title: "", description: "" }],
+    },
+  });
+
+  // Field array para manejar múltiples slides
+  const { fields, append, remove } = useFieldArray({
+    name: "slides",
+    control: form.control,
+  });
+
+  // Manejar solicitud de eliminación
+  const handleDeleteRequest = (index: number) => {
+    // Si solo hay un slide, mostrar un mensaje de error
+    if (fields.length <= 1) {
+      toast({
+        title: "Error",
+        description: "Debe haber al menos un slide en el carrusel",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    // Activar la confirmación para este slide
+    setSlideConfirmingDelete(index);
+  };
+
+  // Confirmar eliminación
+  const confirmDelete = (index: number) => {
+    remove(index);
+    setSlideConfirmingDelete(null);
+  };
+
+  // Cancelar eliminación
+  const cancelDelete = () => {
+    setSlideConfirmingDelete(null);
+  };
+
+  const handleSubmit = async (values: FormValues) => {
+    if (values.slides.length === 0) {
+      toast({
+        title: "Error",
+        description: "Debe haber al menos un slide",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    setIsUploading(true);
+
+    try {
+      // Procesar cada slide para subir imágenes si es necesario
+      const processedSlides = await Promise.all(
+        values.slides.map(async (slide, index) => {
+          let finalImageUrl = slide.image_url;
+
+          // Si la imagen es una base64, subirla al servidor
+          if (slide.image_url.startsWith("data:image")) {
+            const response = await uploadImage(slide.image_url);
+            if (!response.ok || !response.data?.url) {
+              throw new Error(
+                `Error al subir la imagen del slide ${index + 1}`
+              );
+            }
+            finalImageUrl = response.data.url;
+          }
+
+          return {
+            ...slide,
+            index, // Asegurar que el índice sea correcto
+            image_url: finalImageUrl,
+          };
+        })
+      );
+
+      // Preparar datos para enviar
+      const formattedValues: CarouselFormData = {
+        page_id: initialValues?.page_id || "", // Asumimos que ya tenemos el page_id
+        name: values.name,
+        description: values.description,
+        slides: processedSlides,
+      };
+
+      await onSubmit(formattedValues);
+      onClose();
+    } catch (error) {
+      console.error("Error al guardar el carrusel:", error);
+      toast({
+        title: "Error al guardar",
+        description:
+          "Ocurrió un error al guardar los cambios. Por favor, intenta de nuevo.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="max-h-[90vh] overflow-y-auto w-full max-w-2xl p-4 md:p-6">
+        <DialogHeader className="space-y-3 pb-4 border-b">
+          <DialogTitle className="text-xl font-semibold">
+            Editar Carrusel Principal
+          </DialogTitle>
+          <p className="text-sm text-gray-500">
+            Modifique la información del carrusel principal y sus slides.
+          </p>
+        </DialogHeader>
+
+        <Form {...form}>
+          <form
+            onSubmit={form.handleSubmit(handleSubmit)}
+            className="py-4 space-y-6"
+          >
+            <div className="space-y-4">
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Nombre del Carrusel</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Ej: Carrusel Principal" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="description"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Descripción</FormLabel>
+                    <FormControl>
+                      <Textarea
+                        placeholder="Breve descripción del carrusel"
+                        className="resize-none"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <div className="space-y-4">
+              <div className="flex items-center justify-between">
+                <FormLabel className="text-base">Slides</FormLabel>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() =>
+                    append({
+                      index: fields.length,
+                      image_url: "",
+                      title: "",
+                      description: "",
+                    })
+                  }
+                >
+                  <Plus className="w-4 h-4 mr-2" />
+                  Añadir Slide
+                </Button>
+              </div>
+              <FormDescription>
+                Los slides se mostrarán en el carrusel de la página principal.
+                Debe haber al menos uno.
+              </FormDescription>
+
+              {fields.length === 0 && (
+                <p className="text-sm text-red-500">
+                  Debe añadir al menos un slide.
+                </p>
+              )}
+
+              <div className="space-y-4">
+                {fields.map((field, index) => (
+                  <Card key={field.id} className="overflow-hidden relative">
+                    <CardContent className="p-4">
+                      <div className="flex justify-between items-center mb-4">
+                        <h3 className="font-medium">Slide {index + 1}</h3>
+
+                        {slideConfirmingDelete === index ? (
+                          <div className="flex items-center space-x-2 bg-red-50 py-1 px-2 rounded-md">
+                            <span className="text-xs text-red-600 font-medium">
+                              ¿Eliminar?
+                            </span>
+                            <div className="flex space-x-1">
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => confirmDelete(index)}
+                                className="h-6 w-6 p-0 text-red-600 hover:text-red-700 hover:bg-red-100"
+                              >
+                                <Check className="h-4 w-4" />
+                              </Button>
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="sm"
+                                onClick={cancelDelete}
+                                className="h-6 w-6 p-0 text-gray-600 hover:text-gray-700 hover:bg-gray-100"
+                              >
+                                <X className="h-4 w-4" />
+                              </Button>
+                            </div>
+                          </div>
+                        ) : (
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => handleDeleteRequest(index)}
+                            className="h-8 w-8 p-0 text-red-500 hover:text-red-700 hover:bg-red-50"
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </Button>
+                        )}
+                      </div>
+
+                      <div className="space-y-4">
+                        <FormField
+                          control={form.control}
+                          name={`slides.${index}.title`}
+                          render={({ field }) => (
+                            <FormItem>
+                              <FormLabel>Título</FormLabel>
+                              <FormControl>
+                                <Input
+                                  placeholder="Título del slide"
+                                  {...field}
+                                />
+                              </FormControl>
+                              <FormMessage />
+                            </FormItem>
+                          )}
+                        />
+
+                        <FormField
+                          control={form.control}
+                          name={`slides.${index}.description`}
+                          render={({ field }) => (
+                            <FormItem>
+                              <FormLabel>Descripción</FormLabel>
+                              <FormControl>
+                                <Textarea
+                                  placeholder="Descripción breve del slide"
+                                  className="resize-none"
+                                  {...field}
+                                />
+                              </FormControl>
+                              <FormMessage />
+                            </FormItem>
+                          )}
+                        />
+
+                        <FormField
+                          control={form.control}
+                          name={`slides.${index}.image_url`}
+                          render={({ field }) => (
+                            <FormItem>
+                              <FormLabel>Imagen</FormLabel>
+                              <FormControl>
+                                <ImageUpload
+                                  value={field.value}
+                                  onChange={field.onChange}
+                                  onClear={() => field.onChange("")}
+                                  error={
+                                    !!form.formState.errors.slides?.[index]
+                                      ?.image_url
+                                  }
+                                />
+                              </FormControl>
+                              <FormMessage />
+                            </FormItem>
+                          )}
+                        />
+
+                        {/* Este campo es oculto, solo para mantener el índice */}
+                        <input
+                          type="hidden"
+                          {...form.register(`slides.${index}.index`)}
+                          value={index}
+                        />
+                      </div>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+            </div>
+
+            <DialogFooter className="pt-4">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={onClose}
+                disabled={isUploading}
+              >
+                Cancelar
+              </Button>
+              <Button
+                type="submit"
+                className="text-white"
+                disabled={isUploading}
+              >
+                {isUploading ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Procesando...
+                  </>
+                ) : (
+                  "Guardar Cambios"
+                )}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default CarouselForm;

--- a/src/features/admin/constants/navigationItems.ts
+++ b/src/features/admin/constants/navigationItems.ts
@@ -1,4 +1,4 @@
-import { Home, User, ChartBar } from "lucide-react";
+import { Home, User, ChartBar, Layout } from "lucide-react";
 import { MdOutlineMuseum, MdTour } from "react-icons/md";
 
 export const navigationItems = [
@@ -21,6 +21,11 @@ export const navigationItems = [
     title: "Recorridos",
     icon: MdTour,
     url: "/admin/tours",
+  },
+  {
+    title: "Landing",
+    icon: Layout,
+    url: "/admin/landing",
   },
   {
     title: "Estadísticas",

--- a/src/features/admin/routes/index.tsx
+++ b/src/features/admin/routes/index.tsx
@@ -3,6 +3,7 @@ import AdminMuseums from "@/pages/admin/AdminMuseums";
 import AdminStatistics from "@/pages/admin/AdminStats";
 import AdminTours from "@/pages/admin/AdminTours";
 import AdminUsers from "@/pages/admin/AdminUsers";
+import LandingPage from "@/pages/admin/LandingPage";
 
 const adminRoutes = {
   children: [
@@ -16,6 +17,10 @@ const adminRoutes = {
     {
       path: "tours",
       element: <AdminTours />,
+    },
+    {
+      path: "/admin/landing",
+      element: <LandingPage />,
     },
   ],
 };

--- a/src/pages/admin/LandingPage.tsx
+++ b/src/pages/admin/LandingPage.tsx
@@ -1,0 +1,260 @@
+import { useEffect, useState } from "react";
+import {
+  AlertCircle,
+  Edit,
+  Image,
+  RefreshCw,
+  ChevronLeft,
+  ChevronRight,
+} from "lucide-react";
+// Importaciones de Swiper
+import { Swiper, SwiperSlide } from "swiper/react";
+import { Navigation, Pagination } from "swiper/modules";
+import "swiper/css";
+import "swiper/css/pagination";
+
+// Components
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import CarouselForm from "@/features/admin/components/CarouselForm";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+
+// Services
+import { getMainCarousel, updateCarousel } from "@/services/Carousel";
+
+// Types
+import { Carousel, CarouselFormData } from "@/shared/types/Carousel";
+import { useToast } from "@/hooks/use-toast";
+
+const LandingPage = () => {
+  // Estados
+  const [carousel, setCarousel] = useState<Carousel | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isFormOpen, setIsFormOpen] = useState(false);
+
+  const { toast } = useToast();
+
+  // Cargar datos del carrusel principal
+  const fetchCarousel = async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await getMainCarousel();
+
+      if (response.ok && response.data) {
+        setCarousel(response.data);
+      } else {
+        setError(response.message || "Error al cargar el carrusel principal");
+      }
+    } catch (error) {
+      console.error("Error fetching carousel:", error);
+      setError("Error al cargar el carrusel principal");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchCarousel();
+  }, []);
+
+  // Manejar actualización del carrusel
+  const handleUpdateCarousel = async (data: CarouselFormData) => {
+    if (!carousel) return;
+
+    try {
+      const response = await updateCarousel(carousel.id, data);
+
+      if (response.ok) {
+        toast({
+          title: "Éxito",
+          description: "Carrusel actualizado correctamente",
+        });
+        fetchCarousel(); // Recargar datos
+      } else {
+        toast({
+          title: "Error",
+          description: response.message || "Error al actualizar el carrusel",
+          variant: "destructive",
+        });
+      }
+    } catch (error) {
+      console.error("Error updating carousel:", error);
+      toast({
+        title: "Error",
+        description: "Error al actualizar el carrusel",
+        variant: "destructive",
+      });
+    }
+  };
+
+  return (
+    <div className="container p-6 mx-auto space-y-8">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold tracking-tight">
+          Gestión de Landing Page
+        </h1>
+
+        <Button onClick={fetchCarousel} variant="outline" disabled={isLoading}>
+          <RefreshCw
+            className={`h-4 w-4 mr-2 ${isLoading ? "animate-spin" : ""}`}
+          />
+          Actualizar
+        </Button>
+      </div>
+
+      {error && (
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>Error</AlertTitle>
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      {/* Sección del carrusel principal */}
+      <div className="space-y-6">
+        <Card>
+          <CardHeader className="pb-2">
+            {/* Rediseño responsive del header */}
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+              <div>
+                <CardTitle className="text-xl">
+                  Carrusel: {carousel ? `${carousel.name}` : "Carrusel"}
+                </CardTitle>
+                <CardDescription>{carousel?.description}</CardDescription>
+                <div className="text-sm text-gray-500">
+                  {carousel ? `${carousel.slides.length} slides` : "0 slides"}
+                </div>
+              </div>
+
+              <Button
+                onClick={() => setIsFormOpen(true)}
+                disabled={!carousel || isLoading}
+                className="text-white self-start sm:self-center w-full sm:w-auto"
+              >
+                <Edit className="h-4 w-4 mr-2" />
+                Editar Carrusel
+              </Button>
+            </div>
+          </CardHeader>
+          <CardContent>
+            {isLoading ? (
+              <div className="flex justify-center p-8">
+                <RefreshCw className="h-8 w-8 animate-spin text-gray-400" />
+              </div>
+            ) : carousel ? (
+              <div className="space-y-4">
+                <h3 className="font-medium mt-6">Vista previa de slides</h3>
+                {/* Contenedor de Swiper con botones personalizados */}
+                <div className="mt-4 relative max-w-3xl mx-auto px-12">
+                  {/* Botones de navegación fuera del slider */}
+                  <div className="absolute -left-3 top-1/2 transform -translate-y-1/2 z-10">
+                    <button className="flex items-center justify-center h-10 w-10 rounded-full bg-white shadow-md hover:bg-gray-50 transition-colors custom-prev-button">
+                      <ChevronLeft className="h-5 w-5 text-gray-600" />
+                    </button>
+                  </div>
+                  <div className="absolute -right-3 top-1/2 transform -translate-y-1/2 z-10">
+                    <button className="flex items-center justify-center h-10 w-10 rounded-full bg-white shadow-md hover:bg-gray-50 transition-colors custom-next-button">
+                      <ChevronRight className="h-5 w-5 text-gray-600" />
+                    </button>
+                  </div>
+
+                  <Swiper
+                    modules={[Navigation, Pagination]}
+                    navigation={{
+                      nextEl: ".custom-next-button",
+                      prevEl: ".custom-prev-button",
+                    }}
+                    pagination={{
+                      clickable: true,
+                      bulletClass:
+                        "inline-block h-2 w-2 rounded-full bg-gray-300 mx-1 cursor-pointer transition-all",
+                      bulletActiveClass: "bg-primary w-6",
+                      el: ".custom-pagination",
+                    }}
+                    slidesPerView={1}
+                    loop={true}
+                    className="rounded-lg border overflow-hidden"
+                  >
+                    {carousel.slides.map((slide) => (
+                      <SwiperSlide key={slide.id || slide.index}>
+                        <div className="h-60 bg-gray-100">
+                          {slide.image_url ? (
+                            <img
+                              src={slide.image_url}
+                              alt={slide.title || "Slide image"}
+                              className="w-full h-full object-cover object-center"
+                            />
+                          ) : (
+                            <div className="flex items-center justify-center h-full">
+                              <Image className="h-12 w-12 text-gray-300" />
+                            </div>
+                          )}
+                        </div>
+                        <div className="p-4 bg-white border-t">
+                          <h4 className="font-medium">
+                            {slide.title || "Sin título"}
+                          </h4>
+                          <p className="text-sm text-gray-500 mt-1">
+                            {slide.description || "Sin descripción"}
+                          </p>
+                        </div>
+                      </SwiperSlide>
+                    ))}
+                  </Swiper>
+
+                  {/* Paginación personalizada */}
+                  <div className="custom-pagination flex justify-center mt-4"></div>
+                </div>
+
+                {/* Información adicional */}
+                <div className="bg-gray-50 p-4 rounded-md mt-4">
+                  <h4 className="text-sm font-medium text-gray-700">
+                    Información adicional
+                  </h4>
+                  <p className="text-xs text-gray-500 mt-1">
+                    Los slides se{" "}
+                    <span className="font-semibold">
+                      mostrarán en el carrusel de la página principal
+                    </span>{" "}
+                    en el orden definido. Puedes editar cada slide desde el
+                    botón{" "}
+                    <span className="font-semibold">"Editar Carrusel"</span>.
+                    Desliza horizontalmente o utiliza las flechas para navegar
+                    entre slides.
+                  </p>
+                </div>
+              </div>
+            ) : (
+              <div className="text-center p-8">
+                <p className="text-gray-500">
+                  No se encontró el carrusel principal
+                </p>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Formulario de edición */}
+      {carousel && (
+        <CarouselForm
+          isOpen={isFormOpen}
+          onClose={() => setIsFormOpen(false)}
+          onSubmit={handleUpdateCarousel}
+          initialValues={carousel}
+        />
+      )}
+    </div>
+  );
+};
+
+export default LandingPage;

--- a/src/services/Carousel.ts
+++ b/src/services/Carousel.ts
@@ -1,0 +1,148 @@
+import axios from "axios";
+import { Carousel, CarouselFormData } from "@/shared/types/Carousel";
+import ResponseData, {
+  ResponseDataTyped,
+} from "@/shared/types/response-data.types";
+
+const apiBaseUrl = import.meta.env.VITE_API_BASE_URL;
+
+// Valor de paginación por defecto
+const defaultPagination = {
+  total: 0,
+  page: 1,
+  limit: 10,
+  hasMore: false,
+};
+
+// Obtener todos los carruseles
+export const getCarousels = async (): Promise<
+  ResponseDataTyped<Carousel[]>
+> => {
+  try {
+    const response = await axios.get<ResponseDataTyped<Carousel[]>>(
+      `${apiBaseUrl}/carousels`
+    );
+    return response.data;
+  } catch (error) {
+    console.error("Error getting carousels:", error);
+    return {
+      ok: false,
+      message: "Error al obtener los carruseles",
+      data: [],
+      pagination: defaultPagination,
+    };
+  }
+};
+
+// Obtener un carrusel específico por ID
+export const getCarouselById = async (
+  id: string
+): Promise<ResponseDataTyped<Carousel>> => {
+  try {
+    const response = await axios.get<ResponseDataTyped<Carousel>>(
+      `${apiBaseUrl}/carousels/${id}`
+    );
+    return response.data;
+  } catch (error) {
+    console.error(`Error getting carousel with id ${id}:`, error);
+    return {
+      ok: false,
+      message: "Error al obtener el carrusel",
+      data: {} as Carousel,
+      pagination: defaultPagination,
+    };
+  }
+};
+
+// Crear un nuevo carrusel
+export const createCarousel = async (
+  data: CarouselFormData
+): Promise<ResponseData> => {
+  try {
+    const response = await axios.post<ResponseData>(
+      `${apiBaseUrl}/carousels`,
+      data
+    );
+    return response.data;
+  } catch (error) {
+    console.error("Error creating carousel:", error);
+    return {
+      ok: false,
+      message: "Error al crear el carrusel",
+      pagination: defaultPagination,
+    };
+  }
+};
+
+// Actualizar un carrusel
+export const updateCarousel = async (
+  id: string,
+  data: CarouselFormData
+): Promise<ResponseData> => {
+  try {
+    const response = await axios.put<ResponseData>(
+      `${apiBaseUrl}/carousels/${id}`,
+      data
+    );
+    return response.data;
+  } catch (error) {
+    console.error(`Error updating carousel with id ${id}:`, error);
+    return {
+      ok: false,
+      message: "Error al actualizar el carrusel",
+      pagination: defaultPagination,
+    };
+  }
+};
+
+// Obtener la landing page
+export const getLandingPage = async (): Promise<ResponseData> => {
+  try {
+    const response = await axios.get<ResponseData>(
+      `${apiBaseUrl}/pages/landing`
+    );
+    return response.data;
+  } catch (error) {
+    console.error("Error getting landing page:", error);
+    return {
+      ok: false,
+      message: "Error al obtener la página de landing",
+      pagination: defaultPagination,
+    };
+  }
+};
+
+// Obtener el carrusel principal de la landing
+export const getMainCarousel = async (): Promise<
+  ResponseDataTyped<Carousel>
+> => {
+  try {
+    // Primero obtenemos todos los carruseles
+    const response = await getCarousels();
+
+    if (!response.ok || !response.data || response.data.length === 0) {
+      return {
+        ok: false,
+        message: "No se encontró el carrusel principal",
+        data: {} as Carousel,
+        pagination: defaultPagination,
+      };
+    }
+
+    // Si hay carruseles, tomamos el primero (que asumimos es el principal)
+    return {
+      ok: true,
+      message: "Carrusel obtenido correctamente",
+      data: response.data[0],
+      pagination: defaultPagination,
+    };
+  } catch (error) {
+    console.error("Error getting main carousel:", error);
+    return {
+      ok: false,
+      message: "Error al obtener el carrusel principal",
+      data: {} as Carousel,
+      pagination: defaultPagination,
+    };
+  }
+};

--- a/src/shared/types/Carousel.ts
+++ b/src/shared/types/Carousel.ts
@@ -1,0 +1,33 @@
+export interface Slide {
+  id?: string;
+  index: number;
+  image_url: string;
+  title: string;
+  description: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface Carousel {
+  id: string;
+  page_id: string;
+  name: string;
+  description: string;
+  slides: Slide[];
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface SlideFormData {
+  index: number;
+  image_url: string;
+  title: string;
+  description: string;
+}
+
+export interface CarouselFormData {
+  page_id: string;
+  name: string;
+description: string;
+  slides: SlideFormData[];
+}


### PR DESCRIPTION
## ¿Qué tipo de PR es este?

- [ ] Refactorización
- [x] Funcionalidad
- [ ] Corrección de error
- [ ] Optimización
- [ ] Actualización de documentación

## Descripción
Se implementó la gestión del contenido carrusel principal de la landing page en el panel de administración. Los cambios principales incluyen:

- Actualizacion del SEEDING (en back) para que muestre las SLIDES EXISTENTES (ese commit lo subi directo a dev porque solo es para mostrar las slides como estaban y no con otros datos, para que hagas `git pull` y `npm run seed` en back)
- Creación de tipos de datos para el carrusel
- Implementación de servicio API para manejar operaciones del carrusel
- Adición de ruta y elemento de navegación para la página de landing
- Desarrollo de componentes de interfaz para la gestión del carrusel
- Actualización de componentes de carrusel para consumir datos desde la API

## Recursos útiles
...

## Pruebas
1. Agregar un nuevo slide
2. Editar un slide existente
3. Eliminar un slide
4. Validar que los cambios se reflejen en el carrusel principal

## Capturas de pantalla
Vista previa del modulo de gestion del carrusel principal:

![image](https://github.com/user-attachments/assets/18c5d3e7-3865-4ce1-be2c-22651fef2bf5)

Vista previa de formulario de creacion/edicion del carrusel:

![image](https://github.com/user-attachments/assets/2d998695-d970-4058-bcef-391c72454dc5)

Vista en la landing, el estilo se mantuvo igual:

![image](https://github.com/user-attachments/assets/7067ce0f-5a78-45eb-b23b-1d59e08dabbf)

