### PR TITLE
Muvi 163 refactorizacion comportamiento iframe recorrido

### DIFF
--- a/src/features/tour/components/TourCard/TourCardButtons.tsx
+++ b/src/features/tour/components/TourCard/TourCardButtons.tsx
@@ -2,28 +2,14 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useCheckPurchasedTour } from "@/querys/tour.querys";
 import { useCartStore } from "@/stores/useCartStore";
-import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { ConfirmAlert } from "./SeeTourAlert";
 
 export const TourCardButtons = ({ tourId }: { tourId: string }) => {
-  // ----[ State ]----
-  const [isAlertOpen, setIsAlertOpen] = useState(false);
-
   // ----[ Hooks ]----
   const navigate = useNavigate();
   const { setCartItem } = useCartStore();
   const { data: purchasedResponse, isPending: isPurchasedPending } =
     useCheckPurchasedTour(tourId);
-  
-  console.log(purchasedResponse);
-
-  // ----[ Handlers ]----
-  const handleCloseAlert = () => setIsAlertOpen(false);
-  const handleConfirmAlert = () => {
-    handleCloseAlert();
-    navigate(`/tours/view/${tourId}`);
-  };
 
   // ----[ Render ]----
   if (isPurchasedPending) {
@@ -42,22 +28,11 @@ export const TourCardButtons = ({ tourId }: { tourId: string }) => {
           <Button
             variant="default"
             className="w-full h-12 text-white shadow-none rounded-xl md:w-auto"
-            onClick={() => setIsAlertOpen(true)}
+            onClick={() => navigate(`/tours/view/${tourId}`)}
           >
             Ver tour
           </Button>
         </div>
-        <ConfirmAlert
-          isOpen={isAlertOpen}
-          onClose={handleCloseAlert}
-          onConfirm={handleConfirmAlert}
-          onCancel={handleCloseAlert}
-          title="¿Estás seguro?"
-          description='Al hacer clic en "Continuar", iniciarás el tour y solo tendrás
-            acceso a él por 24 horas.'
-          confirmText="Continuar"
-          cancelText="Cancelar"
-        />
       </>
     );
   } else {

--- a/src/pages/SeeTourPage.tsx
+++ b/src/pages/SeeTourPage.tsx
@@ -5,26 +5,71 @@ import TourIframe from "../shared/components/Tour/TourIframe";
 import ReviewsList from "../components/Reviews/ReviewsList";
 import TourSuggestions from "../components/TourSuggestions/TourSuggestions";
 import { dateFormatter } from "../utils/dateFormatter";
-import { useCheckPurchasedTour, useFetchTourById, useFetchTourUrl } from "@/querys/tour.querys";
+import {
+  useCheckPurchasedTour,
+  useFetchTourById,
+  useFetchTourUrl,
+} from "@/querys/tour.querys";
 import Loader from "@/shared/components/Loader";
+import { useToast } from "@/hooks/use-toast";
+import { ConfirmAlert } from "@/features/tour/components/TourCard/SeeTourAlert";
 
 export default function SeeTourPage() {
   // ----[ State ]----
   const [isBlurred, setIsBlurred] = useState(true);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [showStartConfirm, setShowStartConfirm] = useState(false);
+  const [startTourClicked, setStartTourClicked] = useState(false);
 
   // ----[ Hooks ]----
+  const { toast } = useToast();
   const id = useParams().id ?? "";
   const { data: TourResponse, isPending: TourIsPending } = useFetchTourById(id);
-  const { data: TourPurchaseResponse, isPending: TourPurchaseIsPending } = useCheckPurchasedTour(id);
-  const { data: TourUrlResponse, isPending: TourUrlIsPending } = useFetchTourUrl(id, TourPurchaseResponse?.data?.purchased);
+  const { data: TourPurchaseResponse, isPending: TourPurchaseIsPending } =
+    useCheckPurchasedTour(id);
+
+  // Only fetch the tour URL when the user has clicked the start button
+  const {
+    data: TourUrlResponse,
+    isPending: TourUrlIsPending,
+    error: TourUrlError,
+  } = useFetchTourUrl(
+    id,
+    TourPurchaseResponse?.data?.purchased && startTourClicked
+  );
 
   // ----[ Constants ]----
-  const tour = TourResponse
+  const tour = TourResponse;
 
   // ----[ Handlers ]----
   const handleSubmit = (data: { rating: number; comment: string }) => {
     console.log("Form submitted:", data);
+  };
+
+  const handleStartTourClick = () => {
+    setShowStartConfirm(true);
+  };
+
+  const handleConfirmStart = () => {
+    setShowStartConfirm(false);
+    setStartTourClicked(true);
+  };
+
+  const handleCancelStart = () => {
+    setShowStartConfirm(false);
+  };
+
+  const handleTourLoad = () => {
+    if (TourUrlResponse?.data?.tour_url) {
+      setIsBlurred(false);
+    } else if (TourUrlError) {
+      toast({
+        title: "Error",
+        description:
+          "No se pudo cargar el recorrido. Por favor, intenta de nuevo.",
+        variant: "destructive",
+      });
+    }
   };
 
   // ----[ Render ]----
@@ -32,17 +77,20 @@ export default function SeeTourPage() {
   if (!tour) return <p>Tour not found</p>;
   if (TourPurchaseIsPending) return <Loader />;
   if (!TourPurchaseResponse?.data?.purchased) return <p>Not purchased</p>;
-  if (TourUrlIsPending) return <Loader />;
-  if (!TourUrlResponse?.data?.tour_url) return <p>URL not found</p>;
+
+  // Show loading state only when startTourClicked is true and it's pending
+  const isLoadingTourUrl = startTourClicked && TourUrlIsPending;
 
   return (
     <>
       <div className="relative font-inter text-dark">
         {/* Tour iframe */}
         <TourIframe
-          src={TourUrlResponse?.data?.tour_url}
+          src={TourUrlResponse?.data?.tour_url || ""}
           isBlurred={isBlurred}
-          onStart={() => setIsBlurred(false)}
+          onStart={handleStartTourClick}
+          isLoading={isLoadingTourUrl}
+          onLoad={handleTourLoad}
         />
 
         {/* Content */}
@@ -92,6 +140,17 @@ export default function SeeTourPage() {
             isOpen={isDialogOpen}
             onClose={() => setIsDialogOpen(false)}
             onSubmit={handleSubmit}
+          />
+
+          <ConfirmAlert
+            isOpen={showStartConfirm}
+            onClose={handleCancelStart}
+            onConfirm={handleConfirmStart}
+            onCancel={handleCancelStart}
+            title="¿Estás seguro?"
+            description="Al hacer clic en 'Continuar', iniciarás el tour y solo tendrás acceso a él por 24 horas."
+            confirmText="Continuar"
+            cancelText="Cancelar"
           />
         </section>
       </div>

--- a/src/querys/tour.querys.ts
+++ b/src/querys/tour.querys.ts
@@ -29,11 +29,12 @@ export const useCheckPurchasedTour = (tourId: string, enabled = true) => {
   })
 }
 
-export const useFetchTourUrl = (tourId: string, enabled = true) => {
+export const useFetchTourUrl = (tourId: string, enabled = false) => {
   return useQuery({
     queryKey: [TOURS_QUERY_KEY, "url", tourId],
     queryFn: () => getTourUrl(tourId),
     enabled: !!tourId && enabled,
+    retry: 1, // Limit retries in case of error
   })
 }
 

--- a/src/shared/components/Tour/TourIframe.tsx
+++ b/src/shared/components/Tour/TourIframe.tsx
@@ -1,39 +1,60 @@
+import Loader from "@/shared/components/Loader";
+
 interface TourIframeProps {
   src: string;
   isBlurred: boolean;
   onStart: () => void;
+  isLoading?: boolean;
+  onLoad?: () => void;
 }
 
 export default function TourIframe({
   src,
   isBlurred,
   onStart,
+  isLoading = false,
+  onLoad,
 }: TourIframeProps) {
   return (
     <section className="relative">
-      <iframe
-        className={`w-full transition-all duration-500 ${
-          isBlurred
-            ? "blur-md opacity-50 h-[450px]"
-            : "blur-0 opacity-100 h-[640px]"
-        }`}
-        frameBorder="0"
-        name="tour-iframe"
-        title="tour-iframe"
-        allow="xr-spatial-tracking; gyroscope; accelerometer"
-        allowFullScreen
-        scrolling="no"
-        src={src}
-      ></iframe>
+      {src ? (
+        <iframe
+          className={`w-full transition-all duration-500 ${
+            isBlurred
+              ? "blur-md opacity-50 h-[450px]"
+              : "blur-0 opacity-100 h-[640px]"
+          }`}
+          frameBorder="0"
+          name="tour-iframe"
+          title="tour-iframe"
+          allow="xr-spatial-tracking; gyroscope; accelerometer"
+          allowFullScreen
+          scrolling="no"
+          src={src}
+          onLoad={onLoad}
+        ></iframe>
+      ) : (
+        <div className={`w-full h-[450px] bg-gray-100`}></div>
+      )}
+
       {isBlurred && (
         <div
           className="absolute inset-0 flex flex-col items-center justify-center text-white bg-black bg-opacity-50 cursor-pointer text-center h-[450px]"
-          onClick={onStart}
+          onClick={isLoading ? undefined : onStart}
         >
-          <h2 className="font-semibold tracking-widest">SOLO EN MUVi</h2>
-          <h1 className="mt-2 text-3xl font-medium md:text-5xl font-kaiseiDecol">
-            Empezar este recorrido
-          </h1>
+          {isLoading ? (
+            <div className="flex flex-col items-center">
+              <Loader />
+              <p className="mt-4">Cargando recorrido...</p>
+            </div>
+          ) : (
+            <>
+              <h2 className="font-semibold tracking-widest">SOLO EN MUVi</h2>
+              <h1 className="mt-2 text-3xl font-medium md:text-5xl font-kaiseiDecol">
+                Empezar este recorrido
+              </h1>
+            </>
+          )}
         </div>
       )}
     </section>


### PR DESCRIPTION
## ¿Qué tipo de PR es este?
- [x] Refactorización
- [x] Funcionalidad
- [ ] Corrección de error
- [ ] Optimización
- [ ] Actualización de documentación

## Descripción
Refactorización del comportamiento del iframe de recorrido para proteger las URLs de los tours. Ahora la URL del tour solo se obtiene cuando el usuario hace clic en "Empezar recorrido", en lugar de cargarla automáticamente al entrar a la vista.

Cambios principales:
- Modificado `SeeTourPage` para mostrar el iframe en estado blurred inicialmente
- Actualizado `TourIframe` para soportar estados de carga y transiciones visuales
- Ajustado `useFetchTourUrl` para que solo se active bajo demanda
- Simplificado `TourCardButtons` eliminando el diálogo de confirmación innecesario

## Recursos útiles
El flujo de usuario ahora es:
1. Usuario navega a la página del tour
2. Ve un iframe difuminado con botón "Empezar recorrido"
3. Al hacer clic, aparece un diálogo de confirmación
4. Al confirmar, se obtiene la URL y comienza el conteo de caducidad
5. El iframe se carga y muestra el contenido normalmente

## Pruebas
Para probar estos cambios:
1. Compra un tour o usa uno ya comprado
2. Visita la página del tour en `/tours/view/:id`
3. Verifica que el iframe aparezca difuminado con el texto "Empezar recorrido"
4. Haz clic y confirma en el diálogo
5. Verifica que el iframe se cargue correctamente y muestre el contenido

## Capturas de pantalla
![image](https://github.com/user-attachments/assets/bbe6a01d-9ef1-49e4-ae79-b01217943de8)
