### PR TITLE
Muvi 164 front bugfix items fantasma en carrito

### DIFF
--- a/src/features/cart/components/CartButton.tsx
+++ b/src/features/cart/components/CartButton.tsx
@@ -1,11 +1,27 @@
+import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { AiOutlineShoppingCart } from "react-icons/ai";
-
 import { useCartStore } from '../../../stores/useCartStore';
 
 export default function CartButton() {
-  const { getItemCount } = useCartStore();
+  const { getItemCount, cleanGhostItems } = useCartStore();
   const navigate = useNavigate();
+  
+  // Usar getItemCount() directamente en lugar de mantener un estado local
+  // Esto garantiza que el componente se re-renderice cuando cartItems cambie
+  
+  useEffect(() => {
+    // Limpiar items fantasma al montar el componente
+    const checkGhostItems = async () => {
+      try {
+        await cleanGhostItems();
+      } catch (error) {
+        console.error("Error cleaning ghost items:", error);
+      }
+    };
+    
+    checkGhostItems();
+  }, [cleanGhostItems]);
   
   const handleClick = () => {
     navigate('/cart');

--- a/src/features/cart/components/CartCleaner.tsx
+++ b/src/features/cart/components/CartCleaner.tsx
@@ -1,0 +1,35 @@
+import { useEffect } from 'react';
+import { useCartStore } from '../../../stores/useCartStore';
+
+/**
+ * CartCleaner - Un componente invisible que se encarga de limpiar items fantasma del carrito
+ * Se debería incluir en el layout principal para que se ejecute al cargar la aplicación
+ */
+export const CartCleaner = () => {
+  const { cleanGhostItems } = useCartStore();
+  
+  useEffect(() => {
+    // Limpiar items fantasma al cargar el componente
+    const cleanCart = async () => {
+      try {
+        await cleanGhostItems();
+      } catch (error) {
+        console.error('Error cleaning ghost items:', error);
+      }
+    };
+    
+    cleanCart();
+    
+    // Establecer un intervalo para limpiar periódicamente (opcional)
+    const interval = setInterval(cleanCart, 30 * 60 * 1000); // Cada 30 minutos
+    
+    return () => {
+      clearInterval(interval);
+    };
+  }, [cleanGhostItems]);
+  
+  // No renderiza nada, es un componente funcional
+  return null;
+};
+
+export default CartCleaner;

--- a/src/features/cart/components/CartSuggestions.tsx
+++ b/src/features/cart/components/CartSuggestions.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Tour } from "../../../shared/types/Tour";
 import { CartListItem } from "./CartList";
-import { getTourSuggestions } from "../../../services/tour.services";
+import { getTourSuggestions, checkPurchasedTours } from "../../../services/tour.services";
 import { useCartStore } from "../../../stores/useCartStore";
 import RatingStars from "@/shared/components/RatingStars";
+import { useAuth } from "@/hooks/useAuth";
 
 interface Props {
   cartListData: CartListItem[];
@@ -12,8 +13,10 @@ interface Props {
 
 export const CartSuggestions = ({ cartListData, quantity }: Props) => {
   const [fetchedTour, setFetchedTour] = useState<Tour | null>();
+  const [isLoading, setIsLoading] = useState(false);
 
   const { setCartItem } = useCartStore();
+  const { isAuthenticated } = useAuth();
 
   const tourIds = useMemo(
     () => cartListData.map((item) => item.id),
@@ -21,14 +24,70 @@ export const CartSuggestions = ({ cartListData, quantity }: Props) => {
   );
 
   const fetchTourSuggestion = useCallback(async () => {
-    const response = await getTourSuggestions(tourIds, quantity);
-    if (!response.ok) return;
-    setFetchedTour(response.data[0]);
-  }, [tourIds, quantity]);
+    setIsLoading(true);
+    try {
+      // Paso 1: Obtener las sugerencias
+      const response = await getTourSuggestions(tourIds, quantity + 5); // Pedir más por si hay que filtrar
+      if (!response.ok || !response.data || response.data.length === 0) {
+        setFetchedTour(null);
+        return;
+      }
+      
+      let suggestedTours = response.data;
+      
+      // Paso 2: Si el usuario está autenticado, filtrar tours con acceso activo
+      if (isAuthenticated && suggestedTours.length > 0) {
+        // Obtener IDs de los tours sugeridos
+        const suggestedTourIds = suggestedTours.map((tour: Tour) => tour.id);
+        
+        // Verificar cuáles tienen acceso activo
+        const purchasedResponse = await checkPurchasedTours(suggestedTourIds);
+        
+        if (purchasedResponse?.ok && purchasedResponse.data && purchasedResponse.data.length > 0) {
+          // Filtrar tours que no tienen acceso activo
+          const activeTourIds = new Set(purchasedResponse.data);
+          suggestedTours = suggestedTours.filter((tour: Tour) => !activeTourIds.has(tour.id));
+        }
+      }
+      
+      // Si después de filtrar queda al menos un tour, mostrar el primero
+      if (suggestedTours.length > 0) {
+        setFetchedTour(suggestedTours[0]);
+      } else {
+        setFetchedTour(null);
+      }
+    } catch (error) {
+      console.error("Error fetching tour suggestions:", error);
+      setFetchedTour(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [tourIds, quantity, isAuthenticated]);
 
   useEffect(() => {
     fetchTourSuggestion();
   }, [fetchTourSuggestion]);
+
+  if (isLoading) {
+    return (
+      <div>
+        <div className="text-center">
+          <h1 className="text-2xl font-kaiseiDecol">Podría Interesarte</h1>
+        </div>
+        <hr className="w-full h-0.5 bg-gray-200 border-0 rounded my-4"></hr>
+        <div className="flex justify-center items-center h-24">
+          <div className="animate-pulse w-full">
+            <div className="bg-gray-200 h-24 w-full rounded-lg"></div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Si no hay tour para sugerir, mostrar un mensaje alternativo o nada
+  if (!fetchedTour) {
+    return null;
+  }
 
   return (
     <div>
@@ -38,14 +97,14 @@ export const CartSuggestions = ({ cartListData, quantity }: Props) => {
       <hr className="w-full h-0.5 bg-gray-200 border-0 rounded my-4"></hr>
       <div className="flex flex-col gap-3">
         <div className="p-2 flex flex-col gap-2">
-          {fetchedTour && <TourCard tour={fetchedTour} />}
+          <TourCard tour={fetchedTour} />
         </div>
         <div className="flex">
           <button
             className="mx-auto px-6 border bg-primary text-white p-2 rounded-xl hover:bg-primaryHover hover:text-white transition-colors duration-300"
             onClick={() => {
               setCartItem({
-                id: fetchedTour!.id,
+                id: fetchedTour.id,
                 isSelected: true,
                 quantity: 1,
               });

--- a/src/features/tour/components/TourCard/TourCardButtons.tsx
+++ b/src/features/tour/components/TourCard/TourCardButtons.tsx
@@ -2,28 +2,14 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useCheckPurchasedTour } from "@/querys/tour.querys";
 import { useCartStore } from "@/stores/useCartStore";
-import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { ConfirmAlert } from "./SeeTourAlert";
 
 export const TourCardButtons = ({ tourId }: { tourId: string }) => {
-  // ----[ State ]----
-  const [isAlertOpen, setIsAlertOpen] = useState(false);
-
   // ----[ Hooks ]----
   const navigate = useNavigate();
   const { setCartItem } = useCartStore();
   const { data: purchasedResponse, isPending: isPurchasedPending } =
     useCheckPurchasedTour(tourId);
-  
-  console.log(purchasedResponse);
-
-  // ----[ Handlers ]----
-  const handleCloseAlert = () => setIsAlertOpen(false);
-  const handleConfirmAlert = () => {
-    handleCloseAlert();
-    navigate(`/tours/view/${tourId}`);
-  };
 
   // ----[ Render ]----
   if (isPurchasedPending) {
@@ -42,22 +28,11 @@ export const TourCardButtons = ({ tourId }: { tourId: string }) => {
           <Button
             variant="default"
             className="w-full h-12 text-white shadow-none rounded-xl md:w-auto"
-            onClick={() => setIsAlertOpen(true)}
+            onClick={() => navigate(`/tours/view/${tourId}`)}
           >
             Ver tour
           </Button>
         </div>
-        <ConfirmAlert
-          isOpen={isAlertOpen}
-          onClose={handleCloseAlert}
-          onConfirm={handleConfirmAlert}
-          onCancel={handleCloseAlert}
-          title="¿Estás seguro?"
-          description='Al hacer clic en "Continuar", iniciarás el tour y solo tendrás
-            acceso a él por 24 horas.'
-          confirmText="Continuar"
-          cancelText="Cancelar"
-        />
       </>
     );
   } else {

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -1,8 +1,9 @@
 import { Outlet } from "react-router-dom";
 import AppBar from "../components/AppBar/AppBar";
 import Footer from "../components/Footer";
+import CartCleaner from "../features/cart/components/CartCleaner";
 
-export default function AuthProvider() {
+export default function AppLayout() {
   return (
     <div className="font-inter">
       <AppBar />
@@ -10,6 +11,7 @@ export default function AuthProvider() {
         <Outlet />
       </div>
       <Footer />
+      <CartCleaner />
     </div>
   );
 }

--- a/src/pages/CartPage.tsx
+++ b/src/pages/CartPage.tsx
@@ -1,23 +1,25 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useCartStore } from "../stores/useCartStore";
-import { getTours } from "../services/tour.services";
+import { getTours, checkPurchasedTours } from "../services/tour.services";
 import { Tour } from "../shared/types/Tour";
 import { CartSuggestions } from "../features/cart/components/CartSuggestions";
 import { CartList } from "../features/cart/components/CartList";
 import { CartResume } from "../features/cart/components/CartResume";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { EmptyCartMessage } from "@/features/cart/components/EmptyCartMessage";
+import { useToast } from "@/hooks/use-toast";
+import { useAuth } from "@/hooks/useAuth";
 
 export default function CartPage() {
   // ----[ State ]----
   const [fetchedTours, setFetchedTours] = useState<Tour[]>([]);
-  // const [paymentStatus, setPaymentStatus] = useState<string | null>();
-  // const [orderId, setOrderId] = useState<string | null>();
 
   // ----[ Hooks ]----
   const [searchParams] = useSearchParams();
-  const { cartItems, setCartItem } = useCartStore();
+  const { cartItems, setCartItem, removeCartItem } = useCartStore();
   const navigate = useNavigate();
+  const { toast } = useToast();
+  const { isAuthenticated } = useAuth();
 
   // ----[ Memos ]----
   const toursIds = useMemo(() => cartItems.map((item) => item.id), [cartItems]);
@@ -35,10 +37,62 @@ export default function CartPage() {
 
   // ----[ Callbacks ]----
   const fetchTours = useCallback(async () => {
+    if (toursIds.length === 0) return;
+
     const response = await getTours(toursIds);
     if (!response.ok) return;
-    setFetchedTours(response.data);
-  }, [toursIds]);
+
+    const fetchedTours = response.data;
+    setFetchedTours(fetchedTours);
+
+    // Check for ghost items and remove them
+    const fetchedTourIds = fetchedTours.map((tour: Tour) => tour.id);
+    const ghostItemIds = toursIds.filter((id) => !fetchedTourIds.includes(id));
+
+    if (ghostItemIds.length > 0) {
+      // Remove each ghost item from the cart
+      ghostItemIds.forEach((id) => {
+        removeCartItem(id);
+      });
+
+      // Show a toast notification to inform the user
+      toast({
+        title: "Carrito actualizado",
+        description: `Se han eliminado ${ghostItemIds.length} tour(s) que ya no están disponibles.`,
+        variant: "default",
+      });
+    }
+
+    // También verificar tours con compras activas si el usuario está autenticado
+    if (isAuthenticated) {
+      const purchasedToursResponse = await checkPurchasedTours(fetchedTourIds);
+
+      if (
+        purchasedToursResponse?.ok &&
+        (purchasedToursResponse.data ?? []).length > 0
+      ) {
+        const activePurchasedTourIds = purchasedToursResponse.data;
+
+        // Eliminar solo los tours con compras activas del carrito
+        (activePurchasedTourIds ?? []).forEach((id: string) => {
+          removeCartItem(id);
+        });
+
+        // Notificar al usuario
+        toast({
+          title: "Carrito actualizado",
+          description: `Se ${
+            activePurchasedTourIds?.length === 1 ? "ha" : "han"
+          } eliminado ${activePurchasedTourIds?.length} tour${
+            activePurchasedTourIds?.length === 1 ? "" : "s"
+          } que ya ${
+            activePurchasedTourIds?.length === 1 ? "tiene" : "tienen"
+          } acceso activo.`,
+          variant: "default",
+        });
+      }
+    }
+  }, [toursIds, removeCartItem, toast, isAuthenticated]);
 
   // ----[ Effects ]----
   useEffect(() => {
@@ -76,7 +130,11 @@ export default function CartPage() {
       .map((item) => item.id);
 
     if (selectedItems.length === 0) {
-      alert("No hay tours seleccionados");
+      toast({
+        title: "No hay tours seleccionados",
+        description: "Por favor, selecciona al menos un tour para continuar.",
+        variant: "destructive",
+      });
       return;
     }
 

--- a/src/pages/CheckoutPage.tsx
+++ b/src/pages/CheckoutPage.tsx
@@ -1,6 +1,6 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
-import { getTours } from "../services/tour.services";
+import { getTours, checkPurchasedTours } from "../services/tour.services";
 import { Tour } from "../shared/types/Tour";
 import Skeleton from "../shared/components/Skeleton";
 import { useCartStore } from "../stores/useCartStore";
@@ -19,13 +19,15 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import Loader from "@/shared/components/Loader";
+import { useToast } from "@/hooks/use-toast";
 
 export function CheckoutPage() {
   const navigate = useNavigate();
   const location = useLocation();
-  const { cartItems } = useCartStore();
+  const { cartItems, removeCartItem } = useCartStore();
   const { isAuthenticated } = useAuth();
   const [orderState, setOrderState] = useState("Cart");
+  const { toast } = useToast();
   const [errorDialog, setErrorDialog] = useState({
     isOpen: false,
     title: "",
@@ -50,6 +52,79 @@ export function CheckoutPage() {
     [toursResponse]
   );
 
+  // Check for ghost items and purchased items
+  useEffect(() => {
+    if (toursResponse?.ok && tourIds.length > 0) {
+      const fetchedTourIds = tours.map((tour) => tour.id);
+
+      // Check for ghost items
+      const ghostItemIds = tourIds.filter((id) => !fetchedTourIds.includes(id));
+
+      if (ghostItemIds.length > 0) {
+        // Remove each ghost item from the cart
+        ghostItemIds.forEach((id) => {
+          removeCartItem(id);
+        });
+
+        // Show a toast notification to inform the user
+        toast({
+          title: "Carrito actualizado",
+          description: `Se han eliminado ${ghostItemIds.length} tour(s) que ya no están disponibles.`,
+          variant: "default",
+        });
+      }
+
+      // Check for purchased tours with active access
+      const checkPurchased = async () => {
+        if (isAuthenticated && fetchedTourIds.length > 0) {
+          const purchasedToursResponse = await checkPurchasedTours(
+            fetchedTourIds
+          );
+
+          if (
+            purchasedToursResponse?.ok &&
+            (purchasedToursResponse.data?.length ?? 0) > 0
+          ) {
+            const activePurchasedTourIds = purchasedToursResponse.data || [];
+
+            // Eliminar solo los tours con compras activas del carrito
+            activePurchasedTourIds.forEach((id) => {
+              removeCartItem(id);
+            });
+
+            // Notificar al usuario y redirigir al carrito si todos los tours tienen acceso activo
+            toast({
+              title: "Carrito actualizado",
+              description: `Se ${
+                activePurchasedTourIds.length === 1 ? "ha" : "han"
+              } eliminado ${activePurchasedTourIds.length} tour${
+                activePurchasedTourIds.length === 1 ? "" : "s"
+              } que ya ${
+                activePurchasedTourIds.length === 1 ? "tiene" : "tienen"
+              } acceso activo.`,
+              variant: "default",
+            });
+
+            // Si todos los tours tienen acceso activo, redirigir al carrito
+            if (activePurchasedTourIds.length === fetchedTourIds.length) {
+              navigate("/cart", { replace: true });
+            }
+          }
+        }
+      };
+
+      checkPurchased();
+    }
+  }, [
+    toursResponse,
+    tourIds,
+    tours,
+    removeCartItem,
+    toast,
+    isAuthenticated,
+    navigate,
+  ]);
+
   // Cálculo del total
   const total = useMemo(
     () => tours.reduce((acc, tour) => acc + Number(tour.price), 0).toFixed(2),
@@ -72,10 +147,29 @@ export function CheckoutPage() {
 
   const handlePay = async (): Promise<void> => {
     try {
-      if (!toursResponse?.ok || toursResponse.data.length !== tourIds.length) {
+      if (!toursResponse?.ok) {
+        return showError(
+          "Error al cargar tours",
+          "No se pudieron cargar los detalles de los tours."
+        );
+      }
+
+      if (toursResponse.data.length !== tourIds.length) {
         return showError(
           "Tours no disponibles",
-          "Algunos tours ya no están disponibles."
+          "Algunos tours seleccionados ya no están disponibles."
+        );
+      }
+
+      // Verificar nuevamente si hay tours comprados antes de proceder
+      const purchasedToursResponse = await checkPurchasedTours(tourIds);
+      if (
+        purchasedToursResponse?.ok &&
+        (purchasedToursResponse.data?.length ?? 0) > 0
+      ) {
+        return showError(
+          "Tours ya comprados",
+          "Algunos tours ya han sido comprados previamente."
         );
       }
 

--- a/src/pages/SeeTourPage.tsx
+++ b/src/pages/SeeTourPage.tsx
@@ -5,26 +5,71 @@ import TourIframe from "../shared/components/Tour/TourIframe";
 import ReviewsList from "../components/Reviews/ReviewsList";
 import TourSuggestions from "../components/TourSuggestions/TourSuggestions";
 import { dateFormatter } from "../utils/dateFormatter";
-import { useCheckPurchasedTour, useFetchTourById, useFetchTourUrl } from "@/querys/tour.querys";
+import {
+  useCheckPurchasedTour,
+  useFetchTourById,
+  useFetchTourUrl,
+} from "@/querys/tour.querys";
 import Loader from "@/shared/components/Loader";
+import { useToast } from "@/hooks/use-toast";
+import { ConfirmAlert } from "@/features/tour/components/TourCard/SeeTourAlert";
 
 export default function SeeTourPage() {
   // ----[ State ]----
   const [isBlurred, setIsBlurred] = useState(true);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [showStartConfirm, setShowStartConfirm] = useState(false);
+  const [startTourClicked, setStartTourClicked] = useState(false);
 
   // ----[ Hooks ]----
+  const { toast } = useToast();
   const id = useParams().id ?? "";
   const { data: TourResponse, isPending: TourIsPending } = useFetchTourById(id);
-  const { data: TourPurchaseResponse, isPending: TourPurchaseIsPending } = useCheckPurchasedTour(id);
-  const { data: TourUrlResponse, isPending: TourUrlIsPending } = useFetchTourUrl(id, TourPurchaseResponse?.data?.purchased);
+  const { data: TourPurchaseResponse, isPending: TourPurchaseIsPending } =
+    useCheckPurchasedTour(id);
+
+  // Only fetch the tour URL when the user has clicked the start button
+  const {
+    data: TourUrlResponse,
+    isPending: TourUrlIsPending,
+    error: TourUrlError,
+  } = useFetchTourUrl(
+    id,
+    TourPurchaseResponse?.data?.purchased && startTourClicked
+  );
 
   // ----[ Constants ]----
-  const tour = TourResponse
+  const tour = TourResponse;
 
   // ----[ Handlers ]----
   const handleSubmit = (data: { rating: number; comment: string }) => {
     console.log("Form submitted:", data);
+  };
+
+  const handleStartTourClick = () => {
+    setShowStartConfirm(true);
+  };
+
+  const handleConfirmStart = () => {
+    setShowStartConfirm(false);
+    setStartTourClicked(true);
+  };
+
+  const handleCancelStart = () => {
+    setShowStartConfirm(false);
+  };
+
+  const handleTourLoad = () => {
+    if (TourUrlResponse?.data?.tour_url) {
+      setIsBlurred(false);
+    } else if (TourUrlError) {
+      toast({
+        title: "Error",
+        description:
+          "No se pudo cargar el recorrido. Por favor, intenta de nuevo.",
+        variant: "destructive",
+      });
+    }
   };
 
   // ----[ Render ]----
@@ -32,17 +77,20 @@ export default function SeeTourPage() {
   if (!tour) return <p>Tour not found</p>;
   if (TourPurchaseIsPending) return <Loader />;
   if (!TourPurchaseResponse?.data?.purchased) return <p>Not purchased</p>;
-  if (TourUrlIsPending) return <Loader />;
-  if (!TourUrlResponse?.data?.tour_url) return <p>URL not found</p>;
+
+  // Show loading state only when startTourClicked is true and it's pending
+  const isLoadingTourUrl = startTourClicked && TourUrlIsPending;
 
   return (
     <>
       <div className="relative font-inter text-dark">
         {/* Tour iframe */}
         <TourIframe
-          src={TourUrlResponse?.data?.tour_url}
+          src={TourUrlResponse?.data?.tour_url || ""}
           isBlurred={isBlurred}
-          onStart={() => setIsBlurred(false)}
+          onStart={handleStartTourClick}
+          isLoading={isLoadingTourUrl}
+          onLoad={handleTourLoad}
         />
 
         {/* Content */}
@@ -92,6 +140,17 @@ export default function SeeTourPage() {
             isOpen={isDialogOpen}
             onClose={() => setIsDialogOpen(false)}
             onSubmit={handleSubmit}
+          />
+
+          <ConfirmAlert
+            isOpen={showStartConfirm}
+            onClose={handleCancelStart}
+            onConfirm={handleConfirmStart}
+            onCancel={handleCancelStart}
+            title="¿Estás seguro?"
+            description="Al hacer clic en 'Continuar', iniciarás el tour y solo tendrás acceso a él por 24 horas."
+            confirmText="Continuar"
+            cancelText="Cancelar"
           />
         </section>
       </div>

--- a/src/querys/tour.querys.ts
+++ b/src/querys/tour.querys.ts
@@ -29,11 +29,12 @@ export const useCheckPurchasedTour = (tourId: string, enabled = true) => {
   })
 }
 
-export const useFetchTourUrl = (tourId: string, enabled = true) => {
+export const useFetchTourUrl = (tourId: string, enabled = false) => {
   return useQuery({
     queryKey: [TOURS_QUERY_KEY, "url", tourId],
     queryFn: () => getTourUrl(tourId),
     enabled: !!tourId && enabled,
+    retry: 1, // Limit retries in case of error
   })
 }
 

--- a/src/services/tour.services.ts
+++ b/src/services/tour.services.ts
@@ -33,8 +33,55 @@ export const checkPurchasedTour = async (tourId: string): Promise<ResponseDataTy
       headers: getAuthHeaders(),
     }
   );
-  console.log(response.data);
   return response.data;
+}
+
+// Verificar múltiples tours comprados
+export const checkPurchasedTours = async (tourIds: string[]): Promise<ResponseDataTyped<string[]>> => {
+  try {
+    // Si no hay token o no hay tours para verificar, retornamos un array vacío
+    const token = localStorage.getItem("auth-token");
+    if (!token || tourIds.length === 0) {
+      return {
+        ok: true,
+        message: "No hay tours para verificar",
+        data: [],
+        pagination: { total: 0, page: 1, limit: 10, hasMore: false }
+      };
+    }
+
+    // Verificar cada tour individualmente y recopilar los IDs de los comprados activos
+    const purchaseChecks = await Promise.all(
+      tourIds.map(async (id) => {
+        try {
+          const response = await checkPurchasedTour(id);
+          // Solo consideramos comprado si purchased es true (si está activo)
+          return response.data?.purchased ? id : null;
+        } catch (error) {
+          console.error(`Error verificando compra del tour ${id}:`, error);
+          return null;
+        }
+      })
+    );
+
+    // Filtrar solo los IDs de tours que tienen compras activas (no nulos)
+    const activePurchasedTourIds = purchaseChecks.filter(id => id !== null) as string[];
+
+    return {
+      ok: true,
+      message: "Verificación de compras completada",
+      data: activePurchasedTourIds,
+      pagination: { total: activePurchasedTourIds.length, page: 1, limit: 10, hasMore: false }
+    };
+  } catch (error) {
+    console.error("Error al verificar tours comprados:", error);
+    return {
+      ok: false,
+      message: "Error al verificar tours comprados",
+      data: [],
+      pagination: { total: 0, page: 1, limit: 10, hasMore: false }
+    };
+  }
 }
 
 export const getTourUrl = async (tourId: string): Promise<ResponseDataTyped<{ tour_url: string }>> => {

--- a/src/shared/components/Tour/TourIframe.tsx
+++ b/src/shared/components/Tour/TourIframe.tsx
@@ -1,39 +1,60 @@
+import Loader from "@/shared/components/Loader";
+
 interface TourIframeProps {
   src: string;
   isBlurred: boolean;
   onStart: () => void;
+  isLoading?: boolean;
+  onLoad?: () => void;
 }
 
 export default function TourIframe({
   src,
   isBlurred,
   onStart,
+  isLoading = false,
+  onLoad,
 }: TourIframeProps) {
   return (
     <section className="relative">
-      <iframe
-        className={`w-full transition-all duration-500 ${
-          isBlurred
-            ? "blur-md opacity-50 h-[450px]"
-            : "blur-0 opacity-100 h-[640px]"
-        }`}
-        frameBorder="0"
-        name="tour-iframe"
-        title="tour-iframe"
-        allow="xr-spatial-tracking; gyroscope; accelerometer"
-        allowFullScreen
-        scrolling="no"
-        src={src}
-      ></iframe>
+      {src ? (
+        <iframe
+          className={`w-full transition-all duration-500 ${
+            isBlurred
+              ? "blur-md opacity-50 h-[450px]"
+              : "blur-0 opacity-100 h-[640px]"
+          }`}
+          frameBorder="0"
+          name="tour-iframe"
+          title="tour-iframe"
+          allow="xr-spatial-tracking; gyroscope; accelerometer"
+          allowFullScreen
+          scrolling="no"
+          src={src}
+          onLoad={onLoad}
+        ></iframe>
+      ) : (
+        <div className={`w-full h-[450px] bg-gray-100`}></div>
+      )}
+
       {isBlurred && (
         <div
           className="absolute inset-0 flex flex-col items-center justify-center text-white bg-black bg-opacity-50 cursor-pointer text-center h-[450px]"
-          onClick={onStart}
+          onClick={isLoading ? undefined : onStart}
         >
-          <h2 className="font-semibold tracking-widest">SOLO EN MUVi</h2>
-          <h1 className="mt-2 text-3xl font-medium md:text-5xl font-kaiseiDecol">
-            Empezar este recorrido
-          </h1>
+          {isLoading ? (
+            <div className="flex flex-col items-center">
+              <Loader />
+              <p className="mt-4">Cargando recorrido...</p>
+            </div>
+          ) : (
+            <>
+              <h2 className="font-semibold tracking-widest">SOLO EN MUVi</h2>
+              <h1 className="mt-2 text-3xl font-medium md:text-5xl font-kaiseiDecol">
+                Empezar este recorrido
+              </h1>
+            </>
+          )}
         </div>
       )}
     </section>

--- a/src/stores/useCartStore.ts
+++ b/src/stores/useCartStore.ts
@@ -1,5 +1,8 @@
-import { create } from 'zustand'
-import { persist } from 'zustand/middleware'
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import { getTours } from "../services/tour.services";
+import { Tour } from "../shared/types/Tour";
+
 
 interface CartItem {
   id: string;
@@ -8,13 +11,14 @@ interface CartItem {
 }
 
 interface CartState {
-  cartItems: CartItem[]
-  addCartItem: (item: CartItem) => void
-  removeCartItem: (id: string) => void
-  updateCartItemQuantity: (id: string, quantity: number) => void
+  cartItems: CartItem[];
+  addCartItem: (item: CartItem) => void;
+  removeCartItem: (id: string) => void;
+  updateCartItemQuantity: (id: string, quantity: number) => void;
   clearCart: () => void;
   getItemCount: () => number;
   setCartItem: (item: CartItem) => void;
+  cleanGhostItems: () => Promise<string[]>;
 }
 
 export const useCartStore = create(
@@ -23,52 +27,87 @@ export const useCartStore = create(
       cartItems: [],
 
       // adds an item to the cart
-      addCartItem: (item) => set((state) => {
-        const existingItem = state.cartItems.find(i => i.id === item.id)
-        if (existingItem) {
-          return {
-            cartItems: state.cartItems.map(item =>
-              item.id === item.id ? { ...item, quantity: item.quantity + 1 } : item
-            )
+      addCartItem: (item) =>
+        set((state) => {
+          const existingItem = state.cartItems.find((i) => i.id === item.id);
+          if (existingItem) {
+            return {
+              cartItems: state.cartItems.map((item) =>
+                item.id === item.id
+                  ? { ...item, quantity: item.quantity + 1 }
+                  : item
+              ),
+            };
           }
-        }
-        return { cartItems: [...state.cartItems, { ...item, quantity: 1 }] }
-      }),
+          return { cartItems: [...state.cartItems, { ...item, quantity: 1 }] };
+        }),
 
       // sets an item in the cart
-      setCartItem: (item) => set((state) => {
-        const existingItemIndex = state.cartItems.findIndex(i => i.id === item.id)
-        if (existingItemIndex !== -1) {
-          const newCartItems = [...state.cartItems]
-          newCartItems[existingItemIndex] = item
-          return { cartItems: newCartItems }
-        } else {
-          return { cartItems: [...state.cartItems, item] }
-        }
-      }),
+      setCartItem: (item) =>
+        set((state) => {
+          const existingItemIndex = state.cartItems.findIndex(
+            (i) => i.id === item.id
+          );
+          if (existingItemIndex !== -1) {
+            const newCartItems = [...state.cartItems];
+            newCartItems[existingItemIndex] = item;
+            return { cartItems: newCartItems };
+          } else {
+            return { cartItems: [...state.cartItems, item] };
+          }
+        }),
 
       // removes an item from the cart
-      removeCartItem: (id) => set((state) => ({
-        cartItems: state.cartItems.filter(item => item.id !== id)
-      })),
+      removeCartItem: (id) =>
+        set((state) => ({
+          cartItems: state.cartItems.filter((item) => item.id !== id),
+        })),
 
       // updates the quantity of an item in the cart
-      updateCartItemQuantity: (id, quantity) => set((state) => ({
-        cartItems: state.cartItems.map(item =>
-          item.id === id ? { ...item, quantity } : item
-        )
-      })),
+      updateCartItemQuantity: (id, quantity) =>
+        set((state) => ({
+          cartItems: state.cartItems.map((item) =>
+            item.id === id ? { ...item, quantity } : item
+          ),
+        })),
 
       // clears the cart
       clearCart: () => set({ cartItems: [] }),
 
       // returns the total number of items in the cart
-      getItemCount: () => get().cartItems.reduce((sum, item) => sum + item.quantity, 0),
+      getItemCount: () =>
+        get().cartItems.reduce((sum, item) => sum + item.quantity, 0),
+
+      // Función para limpiar elementos fantasma del carrito
+      cleanGhostItems: async () => {
+        const cartIds = get().cartItems.map((item) => item.id);
+        if (cartIds.length === 0) return [];
+
+        try {
+          const response = await getTours(cartIds);
+          if (!response.ok) return [];
+
+          const validIds = response.data.map((tour: Tour) => tour.id);
+          const ghostIds = cartIds.filter((id) => !validIds.includes(id));
+
+          // Eliminar los items fantasma del carrito
+          if (ghostIds.length > 0) {
+            ghostIds.forEach((id) => {
+              get().removeCartItem(id);
+            });
+          }
+
+          return ghostIds;
+        } catch (error) {
+          console.error("Error cleaning ghost items:", error);
+          return [];
+        }
+      },
     }),
-    
+
     {
-      name: 'cart-storage', // localStorage key
+      name: "cart-storage", // localStorage key
       getStorage: () => localStorage,
     }
   )
-)
+);


### PR DESCRIPTION
## ¿Qué tipo de PR es este?
- [ ] Refactorización
- [ ] Funcionalidad
- [x] Corrección de error
- [ ] Optimización
- [ ] Actualización de documentación

## Descripción
Se ha corregido el problema de los "ítems fantasma" en el carrito de compras. Estos ítems se producían cuando un tour era eliminado de la base de datos pero seguía almacenado en localStorage, causando discrepancias en el contador del carrito.

Adicionalmente, se ha mejorado el manejo de tours ya comprados para que:
1. Solo se eliminen del carrito los tours con acceso activo
2. Si un tour ya expiró, se pueda volver a comprar
3. No se muestren en sugerencias los tours con acceso activo

## Recursos útiles
El flujo implementado es el siguiente:
1. Al cargar la aplicación, se ejecuta el componente CartCleaner que:
   - Verifica si hay tours fantasma (IDs que ya no existen en la BD)
   - Verifica si hay tours con acceso activo
   - Elimina ambos tipos del carrito
2. Al navegar al carrito, se realiza la misma verificación
3. En la página de checkout, se valida nuevamente antes de finalizar la compra

## Pruebas
Para probar estos cambios:
1. Agregar varios tours al carrito
2. Comprar uno de ellos
3. Verificar que el tour comprado se elimine automáticamente del carrito
4. Verificar que no aparezca en las sugerencias
5. (Para administradores) Eliminar un tour que esté en el carrito de algún usuario y verificar que se elimine automáticamente al recargar la página

## Capturas de pantalla
N/A - Los cambios son principalmente funcionales y no alteran la apariencia de la interfaz.