### PR TITLE
Muvi 161 front modificar crud de museos para incluir el input de horarios

### DIFF
--- a/src/features/admin/components/HoursDialog.tsx
+++ b/src/features/admin/components/HoursDialog.tsx
@@ -1,5 +1,5 @@
-// src/features/admin/components/HoursDialog.tsx
 import { useState, useEffect } from "react";
+import { z } from "zod";
 import {
   Dialog,
   DialogContent,
@@ -11,7 +11,8 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
 import { cn } from "@/lib/utils";
-import { MuseumHours } from "@/types/Museums";
+import { MuseumHours, dayReverseMap } from "@/types/Museums";
+import { toast } from "@/hooks/use-toast";
 
 interface HoursDialogProps {
   isOpen: boolean;
@@ -21,15 +22,39 @@ interface HoursDialogProps {
   editingDay: string | null;
 }
 
+// Schema de validación con Zod
+const timeSchema = z.string().regex(/^([0-1][0-9]|2[0-3]):[0-5][0-9]$/, {
+  message: "Formato de hora inválido. Use HH:MM (24h)",
+});
+
+// Definición de los días de la semana con sus representaciones
 const daysOfWeek = [
-  { key: "D", label: "Domingo" },
-  { key: "L", label: "Lunes" },
-  { key: "M", label: "Martes" },
-  { key: "M", label: "Miércoles" },
-  { key: "J", label: "Jueves" },
-  { key: "V", label: "Viernes" },
-  { key: "S", label: "Sábado" },
+  { key: "D", label: "Domingo", apiName: "SUNDAY" },
+  { key: "L", label: "Lunes", apiName: "MONDAY" },
+  { key: "M", label: "Martes", apiName: "TUESDAY" },
+  { key: "W", label: "Miércoles", apiName: "WEDNESDAY" },
+  { key: "J", label: "Jueves", apiName: "THURSDAY" },
+  { key: "V", label: "Viernes", apiName: "FRIDAY" },
+  { key: "S", label: "Sábado", apiName: "SATURDAY" },
 ];
+
+// Función auxiliar para convertir un día de español a formato API
+const getApiDayName = (day: string): string => {
+  // Si es uno de los valores especiales, devolverlo tal cual
+  if (day === "all" || day === "weekdays" || day === "weekend") {
+    return day;
+  }
+
+  // Buscar en el mapa inverso
+  for (const [apiDay, spanishDay] of Object.entries(dayReverseMap)) {
+    if (spanishDay === day) {
+      return apiDay;
+    }
+  }
+
+  // Si no se encuentra, asumir que ya está en formato API
+  return day;
+};
 
 const HoursDialog = ({
   isOpen,
@@ -38,82 +63,186 @@ const HoursDialog = ({
   initialHours,
   editingDay,
 }: HoursDialogProps) => {
+  // Estados para el diálogo
   const [selectedDays, setSelectedDays] = useState<string[]>([]);
   const [is24Hours, setIs24Hours] = useState(false);
   const [isClosed, setIsClosed] = useState(false);
   const [openTime, setOpenTime] = useState("");
   const [closeTime, setCloseTime] = useState("");
 
+  // Estados para validación
+  const [errors, setErrors] = useState<{
+    openTime?: string;
+    closeTime?: string;
+    timeComparison?: string;
+  }>({});
+
+  // Inicializar los estados basados en el día seleccionado
   useEffect(() => {
-    if (isOpen && initialHours.length > 0) {
-      let daysToSelect: string[] = [];
+    if (!isOpen) return;
 
-      if (editingDay === "all") {
-        daysToSelect = initialHours.map((h) => h.day);
-        // Resetear estados para edición múltiple
-        setIs24Hours(false);
-        setIsClosed(false);
-        setOpenTime("");
-        setCloseTime("");
-      } else if (editingDay === "weekdays") {
-        daysToSelect = ["Lunes", "Martes", "Miércoles", "Jueves", "Viernes"];
-        // Resetear estados para edición múltiple
-        setIs24Hours(false);
-        setIsClosed(false);
-        setOpenTime("");
-        setCloseTime("");
-      } else if (editingDay) {
-        daysToSelect = [editingDay];
-        // Obtener el horario del día específico que se está editando
-        const referenceHours = initialHours.find((h) => h.day === editingDay);
-        if (referenceHours) {
-          setIs24Hours(
-            referenceHours.isOpen &&
-              (!referenceHours.openTime || !referenceHours.closeTime)
-          );
-          setIsClosed(!referenceHours.isOpen);
-          setOpenTime(referenceHours.openTime || "");
-          setCloseTime(referenceHours.closeTime || "");
-        }
-      }
-
-      setSelectedDays(daysToSelect);
+    // If initialHours is empty or undefined, return early or use a default value
+    if (!initialHours || initialHours.length === 0) {
+      console.log("No hay horas iniciales, utilizando valores predeterminados");
+      // You might want to set some default hours here if needed
+      return;
     }
+
+    let daysToSelect: string[] = [];
+
+    if (editingDay === "all") {
+      // Seleccionar todos los días
+      daysToSelect = initialHours.map((h) => h.day);
+      resetTimeInputs();
+    } else if (editingDay === "weekdays") {
+      // Seleccionar días de semana (lunes-viernes)
+      daysToSelect = ["MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY"];
+      resetTimeInputs();
+    } else if (editingDay === "weekend") {
+      // Seleccionar fin de semana (sábado-domingo)
+      daysToSelect = ["SATURDAY", "SUNDAY"];
+      resetTimeInputs();
+    } else if (editingDay) {
+      // Seleccionar un día específico
+      const dayApiName = getApiDayName(editingDay);
+      daysToSelect = [dayApiName];
+
+      // Cargar la configuración actual del día
+      const dayConfig = initialHours.find((h) => h.day === dayApiName);
+      if (dayConfig) {
+        setIs24Hours(
+          dayConfig.isOpen && (!dayConfig.openTime || !dayConfig.closeTime)
+        );
+        setIsClosed(!dayConfig.isOpen);
+        setOpenTime(dayConfig.openTime || "");
+        setCloseTime(dayConfig.closeTime || "");
+      }
+    }
+
+    setSelectedDays(daysToSelect);
   }, [isOpen, initialHours, editingDay]);
 
-  const handleDayClick = (dayLabel: string) => {
+  // Función para resetear los inputs de tiempo
+  const resetTimeInputs = () => {
+    setIs24Hours(false);
+    setIsClosed(false);
+    setOpenTime("");
+    setCloseTime("");
+    setErrors({});
+  };
+
+  // Manejar la selección/deselección de un día
+  const handleDayClick = (apiDay: string) => {
     setSelectedDays((prev) => {
-      // Si el día está seleccionado y no es el único, quitarlo
-      if (prev.includes(dayLabel)) {
-        return prev.length > 1 ? prev.filter((d) => d !== dayLabel) : prev;
+      // Si ya está seleccionado y no es el único, quitarlo
+      if (prev.includes(apiDay)) {
+        return prev.length > 1 ? prev.filter((d) => d !== apiDay) : prev;
       }
-      // Si no está seleccionado, agregarlo
-      return [...prev, dayLabel];
+      // Añadirlo a la selección
+      return [...prev, apiDay];
     });
   };
 
+  // Validar los horarios
+  const validateHours = (): boolean => {
+    // Resetear errores
+    setErrors({});
+
+    // Si está cerrado o es 24 horas, no hay validación
+    if (isClosed || is24Hours) return true;
+
+    let isValid = true;
+    const newErrors: {
+      openTime?: string;
+      closeTime?: string;
+      timeComparison?: string;
+    } = {};
+
+    // Validar hora de apertura
+    if (!openTime) {
+      newErrors.openTime = "La hora de apertura es obligatoria";
+      isValid = false;
+    } else {
+      try {
+        timeSchema.parse(openTime);
+      } catch (error) {
+        if (error instanceof z.ZodError) {
+          newErrors.openTime = error.errors[0].message;
+          isValid = false;
+        }
+      }
+    }
+
+    // Validar hora de cierre
+    if (!closeTime) {
+      newErrors.closeTime = "La hora de cierre es obligatoria";
+      isValid = false;
+    } else {
+      try {
+        timeSchema.parse(closeTime);
+      } catch (error) {
+        if (error instanceof z.ZodError) {
+          newErrors.closeTime = error.errors[0].message;
+          isValid = false;
+        }
+      }
+    }
+
+    // Comparar horas (apertura debe ser anterior a cierre)
+    if (isValid && openTime && closeTime) {
+      const openMinutes =
+        parseInt(openTime.split(":")[0]) * 60 +
+        parseInt(openTime.split(":")[1]);
+      const closeMinutes =
+        parseInt(closeTime.split(":")[0]) * 60 +
+        parseInt(closeTime.split(":")[1]);
+
+      if (openMinutes >= closeMinutes) {
+        newErrors.timeComparison =
+          "La hora de cierre debe ser posterior a la de apertura";
+        isValid = false;
+      }
+    }
+
+    setErrors(newErrors);
+    return isValid;
+  };
+
+  // Guardar los cambios
   const handleSave = () => {
-    // Crear una copia de los horarios iniciales
+    // Validar horarios si no está cerrado y no es 24 horas
+    if (!isClosed && !is24Hours) {
+      if (!validateHours()) {
+        toast({
+          title: "Error de validación",
+          description: "Por favor, corrija los errores en el formulario.",
+          variant: "destructive",
+        });
+        return;
+      }
+    }
+
     const updatedHours = [...initialHours];
 
-    // Crear el nuevo horario para los días seleccionados
+    // Crear la configuración basada en los estados actuales
     const newSchedule = {
       isOpen: !isClosed,
-      openTime: is24Hours ? undefined : openTime,
-      closeTime: is24Hours ? undefined : closeTime,
+      // Para 24 horas, establecer explícitamente "00:00" y "23:59"
+      openTime: is24Hours ? "00:00" : openTime,
+      closeTime: is24Hours ? "23:59" : closeTime,
     };
+
+    console.log("Nueva configuración de horario:", newSchedule);
 
     // Actualizar cada día seleccionado
     selectedDays.forEach((day) => {
       const index = updatedHours.findIndex((h) => h.day === day);
       if (index !== -1) {
-        updatedHours[index] = {
-          ...updatedHours[index],
-          ...newSchedule,
-        };
+        updatedHours[index] = { ...updatedHours[index], ...newSchedule };
       }
     });
 
+    console.log("Horarios actualizados antes de guardar:", updatedHours);
     onSave(updatedHours);
   };
 
@@ -130,29 +259,32 @@ const HoursDialog = ({
             {daysOfWeek.map((day, index) => (
               <button
                 key={index}
-                onClick={() => handleDayClick(day.label)}
+                onClick={() => handleDayClick(day.apiName)}
                 className={cn(
                   "w-10 h-10 rounded-full flex items-center justify-center font-medium transition-colors",
-                  selectedDays.includes(day.label)
+                  selectedDays.includes(day.apiName)
                     ? "bg-primary text-white"
                     : "bg-gray-100 text-gray-600 hover:bg-gray-200"
                 )}
+                title={day.label}
               >
                 {day.key}
               </button>
             ))}
           </div>
 
-          {/* Checkboxes */}
+          {/* Opciones de horario */}
           <div className="space-y-4">
             <div className="flex items-center gap-2">
               <Checkbox
                 id="24hours"
                 checked={is24Hours}
                 onCheckedChange={(checked) => {
-                  setIs24Hours(checked as boolean);
-                  if (checked) {
+                  const isChecked = !!checked;
+                  setIs24Hours(isChecked);
+                  if (isChecked) {
                     setIsClosed(false);
+                    setErrors({});
                   }
                 }}
                 disabled={isClosed}
@@ -165,9 +297,11 @@ const HoursDialog = ({
                 id="closed"
                 checked={isClosed}
                 onCheckedChange={(checked) => {
-                  setIsClosed(checked as boolean);
-                  if (checked) {
+                  const isChecked = !!checked;
+                  setIsClosed(isChecked);
+                  if (isChecked) {
                     setIs24Hours(false);
+                    setErrors({});
                   }
                 }}
               />
@@ -175,27 +309,56 @@ const HoursDialog = ({
             </div>
           </div>
 
-          {/* Inputs de horario */}
+          {/* Inputs de horario - solo visibles si no está cerrado y no es 24h */}
           {!is24Hours && !isClosed && (
             <div className="space-y-4">
               <div className="grid grid-cols-2 gap-4">
                 <div className="space-y-2">
-                  <Label className="text-gray-500 text-sm">Apertura</Label>
+                  <Label
+                    className={`text-sm ${
+                      errors.openTime ? "text-destructive" : "text-gray-500"
+                    }`}
+                  >
+                    Apertura
+                  </Label>
                   <Input
                     type="time"
                     value={openTime}
                     onChange={(e) => setOpenTime(e.target.value)}
+                    className={errors.openTime ? "border-destructive" : ""}
                   />
+                  {errors.openTime && (
+                    <p className="text-xs text-destructive mt-1">
+                      {errors.openTime}
+                    </p>
+                  )}
                 </div>
                 <div className="space-y-2">
-                  <Label className="text-gray-500 text-sm">Cierre</Label>
+                  <Label
+                    className={`text-sm ${
+                      errors.closeTime ? "text-destructive" : "text-gray-500"
+                    }`}
+                  >
+                    Cierre
+                  </Label>
                   <Input
                     type="time"
                     value={closeTime}
                     onChange={(e) => setCloseTime(e.target.value)}
+                    className={errors.closeTime ? "border-destructive" : ""}
                   />
+                  {errors.closeTime && (
+                    <p className="text-xs text-destructive mt-1">
+                      {errors.closeTime}
+                    </p>
+                  )}
                 </div>
               </div>
+              {errors.timeComparison && (
+                <p className="text-xs text-destructive">
+                  {errors.timeComparison}
+                </p>
+              )}
             </div>
           )}
         </div>

--- a/src/features/admin/components/HoursDisplay.tsx
+++ b/src/features/admin/components/HoursDisplay.tsx
@@ -1,46 +1,152 @@
-import { Clock } from "lucide-react";
+import { useState } from "react";
 import { MuseumHours } from "@/types/Museums";
+import { Clock } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { DataTable } from "@/shared/components/DataTable";
+import { ColumnDef } from "@tanstack/react-table";
 
 interface HoursDisplayProps {
   hours: MuseumHours[];
 }
 
+// Definir el tipo para los datos de la tabla
+interface HourTableData {
+  day: string;
+  schedule: string;
+  isOpen: boolean;
+}
+
 const HoursDisplay = ({ hours }: HoursDisplayProps) => {
-  const getDisplayText = () => {
-    const openDays = hours.filter((h) => h.isOpen);
+  const [open, setOpen] = useState(false);
 
-    if (openDays.length === 0) return "Cerrado";
+  // Mapeo de nombres de días en inglés a español
+  const dayTranslations: Record<string, string> = {
+    MONDAY: "Lunes",
+    TUESDAY: "Martes",
+    WEDNESDAY: "Miércoles",
+    THURSDAY: "Jueves",
+    FRIDAY: "Viernes",
+    SATURDAY: "Sábado",
+    SUNDAY: "Domingo",
+  };
 
+  // Orden correcto de los días para mostrar
+  const dayOrder = [
+    "MONDAY",
+    "TUESDAY",
+    "WEDNESDAY",
+    "THURSDAY",
+    "FRIDAY",
+    "SATURDAY",
+    "SUNDAY",
+  ];
+
+  if (!hours || hours.length === 0) {
+    return (
+      <div className="flex items-center gap-2 text-gray-500">
+        <Clock className="w-4 h-4" />
+        <span>No especificado</span>
+      </div>
+    );
+  }
+
+  // Para mostrar una versión detallada en la tabla de administración
+  const openDays = hours.filter((h) => h.isOpen);
+
+  // Texto de resumen para el botón
+  let summaryText = "";
+
+  if (openDays.length === 0) {
+    summaryText = "Cerrado todos los días";
+  } else {
+    // Verificar si todos los días tienen el mismo horario
     const allSameHours = openDays.every(
       (day) =>
         day.openTime === openDays[0].openTime &&
         day.closeTime === openDays[0].closeTime
     );
 
-    if (allSameHours) {
-      if (openDays.length === 7) {
-        if (
-          openDays[0].openTime === "00:00" &&
-          openDays[0].closeTime === "23:59"
-        ) {
-          return "Abierto 24 horas";
-        }
-        return `Todos los días ${openDays[0].openTime} - ${openDays[0].closeTime}`;
+    // Si todos los días tienen el mismo horario y son los 7 días
+    if (allSameHours && openDays.length === 7) {
+      if (
+        (!openDays[0].openTime && !openDays[0].closeTime) ||
+        (openDays[0].openTime === "00:00" && openDays[0].closeTime === "23:59")
+      ) {
+        summaryText = "Abierto 24 horas";
+      } else {
+        summaryText = `Todos los días ${openDays[0].openTime} - ${openDays[0].closeTime}`;
       }
+    } else {
+      summaryText = `Abierto ${openDays.length} días`;
     }
+  }
 
-    const firstDay = openDays[0];
-    if (firstDay.openTime === "00:00" && firstDay.closeTime === "23:59") {
-      return "Abierto 24 horas";
-    }
-    return `${firstDay.openTime} - ${firstDay.closeTime}`;
-  };
+  // Preparar datos para la tabla (ahora fuera de useMemo)
+  const tableData: HourTableData[] = [...hours]
+    .sort((a, b) => dayOrder.indexOf(a.day) - dayOrder.indexOf(b.day))
+    .map((hour) => ({
+      day: dayTranslations[hour.day] || hour.day,
+      schedule: hour.isOpen
+        ? hour.openTime && hour.closeTime
+          ? `${hour.openTime} - ${hour.closeTime}`
+          : "24 horas"
+        : "Cerrado",
+      isOpen: hour.isOpen,
+    }));
+
+  // Definir las columnas para la tabla
+  const columns: ColumnDef<HourTableData>[] = [
+    {
+      accessorKey: "day",
+      header: "Día",
+    },
+    {
+      accessorKey: "schedule",
+      header: "Horario",
+      cell: ({ row }) => {
+        const isOpen = row.original.isOpen;
+        return (
+          <span className={isOpen ? "text-green-600" : "text-red-500"}>
+            {row.getValue("schedule")}
+          </span>
+        );
+      },
+    },
+  ];
 
   return (
-    <div className="flex items-center gap-2">
-      <Clock className="w-4 h-4" />
-      <span>{getDisplayText()}</span>
-    </div>
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button
+          variant="ghost"
+          className="flex items-center gap-2 p-2 hover:bg-gray-100 rounded"
+        >
+          <Clock className="w-4 h-4" />
+          <span>{summaryText}</span>
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-[500px]">
+        <DialogHeader>
+          <DialogTitle className="text-center">Horarios</DialogTitle>
+        </DialogHeader>
+        <div className="mt-4">
+          <DataTable
+            columns={columns}
+            data={tableData}
+            canCreate={false}
+            canEdit={false}
+            canDelete={false}
+          />
+        </div>
+      </DialogContent>
+    </Dialog>
   );
 };
 

--- a/src/features/admin/components/MuseumForm.tsx
+++ b/src/features/admin/components/MuseumForm.tsx
@@ -1,4 +1,3 @@
-// src/features/admin/components/MuseumForm.tsx
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import * as z from "zod";
@@ -26,13 +25,8 @@ import {
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { CustomSelect } from "@/shared/components/CustomSelect";
+
 import ImageUpload from "@/shared/components/ImageUpload";
 import HoursDialog from "./HoursDialog";
 
@@ -47,6 +41,7 @@ import { useToast } from "@/hooks/use-toast";
 import { Tour } from "@/shared/types/Tour";
 import { MuseumHours } from "@/types/Museums";
 
+// Validation schema with Zod
 const formSchema = z.object({
   name: z.string().min(2, "El nombre debe tener al menos 2 caracteres"),
   description: z
@@ -55,6 +50,24 @@ const formSchema = z.object({
   address_name: z
     .string()
     .min(5, "La dirección debe tener al menos 5 caracteres"),
+  latitude: z
+    .union([
+      z.literal("").transform(() => undefined),
+      z.coerce
+        .number()
+        .min(-90, "La latitud debe estar entre -90 y 90")
+        .max(90, "La latitud debe estar entre -90 y 90"),
+    ])
+    .optional(),
+  longitude: z
+    .union([
+      z.literal("").transform(() => undefined),
+      z.coerce
+        .number()
+        .min(-180, "La longitud debe estar entre -180 y 180")
+        .max(180, "La longitud debe estar entre -180 y 180"),
+    ])
+    .optional(),
   main_tour_id: z.string().uuid().optional().nullable(),
   main_photo: z.string().min(1, "La imagen es requerida"),
 });
@@ -62,13 +75,13 @@ const formSchema = z.object({
 type FormValues = z.infer<typeof formSchema>;
 
 const defaultHours: MuseumHours[] = [
-  { day: "Domingo", isOpen: false },
-  { day: "Lunes", isOpen: false },
-  { day: "Martes", isOpen: false },
-  { day: "Miércoles", isOpen: false },
-  { day: "Jueves", isOpen: false },
-  { day: "Viernes", isOpen: false },
-  { day: "Sábado", isOpen: false },
+  { day: "SUNDAY", isOpen: false },
+  { day: "MONDAY", isOpen: false },
+  { day: "TUESDAY", isOpen: false },
+  { day: "WEDNESDAY", isOpen: false },
+  { day: "THURSDAY", isOpen: false },
+  { day: "FRIDAY", isOpen: false },
+  { day: "SATURDAY", isOpen: false },
 ];
 
 interface MuseumFormProps {
@@ -81,6 +94,8 @@ interface MuseumFormProps {
     description: string;
     address_name: string;
     main_photo: string;
+    latitude?: number;
+    longitude?: number;
     main_tour_id?: string | null;
     hours?: MuseumHours[];
     created_at?: string;
@@ -98,10 +113,15 @@ const MuseumForm = ({
   const [museumTours, setMuseumTours] = useState<Tour[]>([]);
   const [isUploading, setIsUploading] = useState(false);
   const [hoursDialogOpen, setHoursDialogOpen] = useState(false);
-  const [currentEditingDay, setCurrentEditingDay] = useState<string | null>(null);
-  const [museumHours, setMuseumHours] = useState<MuseumHours[]>(
-    initialValues?.hours || defaultHours
+  const [currentEditingDay, setCurrentEditingDay] = useState<string | null>(
+    null
   );
+  const [museumHours, setMuseumHours] = useState<MuseumHours[]>(
+    initialValues?.hours && initialValues.hours.length > 0
+      ? initialValues.hours
+      : defaultHours
+  );
+  const [hoursErrors, setHoursErrors] = useState<string[]>([]);
 
   // Hooks
   const { toast } = useToast();
@@ -113,6 +133,8 @@ const MuseumForm = ({
       name: initialValues?.name || "",
       description: initialValues?.description || "",
       address_name: initialValues?.address_name || "",
+      latitude: initialValues?.latitude || undefined,
+      longitude: initialValues?.longitude || undefined,
       main_tour_id: initialValues?.main_tour_id || null,
       main_photo: initialValues?.main_photo || "",
     },
@@ -135,11 +157,93 @@ const MuseumForm = ({
     fetchMuseumTours();
   }, [fetchMuseumTours]);
 
+  // Función que verifica si hay al menos un día con horario configurado
+  const hasConfiguredHours = () => {
+    return museumHours.some((hour) => hour.isOpen);
+  };
+
+  // Validar los horarios
+  const validateHours = (): boolean => {
+    const errors: string[] = [];
+
+    // Verificar cada día abierto
+    museumHours.forEach((hour) => {
+      if (hour.isOpen) {
+        const dayName =
+          hour.day === "SUNDAY"
+            ? "Domingo"
+            : hour.day === "MONDAY"
+            ? "Lunes"
+            : hour.day === "TUESDAY"
+            ? "Martes"
+            : hour.day === "WEDNESDAY"
+            ? "Miércoles"
+            : hour.day === "THURSDAY"
+            ? "Jueves"
+            : hour.day === "FRIDAY"
+            ? "Viernes"
+            : hour.day === "SATURDAY"
+            ? "Sábado"
+            : hour.day;
+
+        // Si no es 24h (que estaría representado por openTime y closeTime undefined o vacíos)
+        const is24Hours =
+          (!hour.openTime && !hour.closeTime) ||
+          (hour.openTime === "" && hour.closeTime === "") ||
+          (hour.openTime === "00:00" && hour.closeTime === "23:59");
+
+        if (!is24Hours) {
+          // Verificar que tenga hora de apertura
+          if (!hour.openTime || hour.openTime === "") {
+            errors.push(`${dayName}: Falta la hora de apertura`);
+          }
+
+          // Verificar que tenga hora de cierre
+          if (!hour.closeTime || hour.closeTime === "") {
+            errors.push(`${dayName}: Falta la hora de cierre`);
+          }
+
+          // Si tiene ambos valores, verificar que cierre sea posterior a apertura
+          if (hour.openTime && hour.closeTime) {
+            const openMinutes =
+              parseInt(hour.openTime.split(":")[0]) * 60 +
+              parseInt(hour.openTime.split(":")[1]);
+            const closeMinutes =
+              parseInt(hour.closeTime.split(":")[0]) * 60 +
+              parseInt(hour.closeTime.split(":")[1]);
+
+            if (openMinutes >= closeMinutes) {
+              errors.push(
+                `${dayName}: La hora de cierre debe ser posterior a la de apertura`
+              );
+            }
+          }
+        }
+      }
+    });
+
+    setHoursErrors(errors);
+    return errors.length === 0;
+  };
+
   const handleSubmit = async (values: FormValues) => {
+    // Validar horarios si hay al menos un día configurado
+    if (hasConfiguredHours() && !validateHours()) {
+      toast({
+        title: "Error de validación",
+        description:
+          "Hay errores en los horarios del museo. Por favor, revise los campos marcados.",
+        variant: "destructive",
+      });
+      return;
+    }
+
     setIsUploading(true);
 
     try {
       let finalImageUrl = values.main_photo;
+
+      // Si la imagen es nueva (formato data:image), subirla
       if (values.main_photo.startsWith("data:image")) {
         const response = await uploadImage(values.main_photo);
         if (!response.ok || !response.data?.url) {
@@ -148,16 +252,30 @@ const MuseumForm = ({
         finalImageUrl = response.data.url;
       }
 
+      // Asegurarse de que los horarios estén correctamente formateados
+      const formattedHours = museumHours.map((hour) => ({
+        ...hour,
+        // Si es 24 horas o cerrado, establecer valores adecuados
+        openTime: hour.isOpen ? hour.openTime || "00:00" : null,
+        closeTime: hour.isOpen ? hour.closeTime || "23:59" : null,
+      }));
+
+      console.log("Horarios formateados antes de enviar:", formattedHours);
+
+      // Crear el objeto con todos los datos
       const formattedValues = {
         ...values,
         main_photo: finalImageUrl,
-        hours: museumHours,
+        hours: formattedHours, // Siempre incluir hours
       };
+
+      console.log("Enviando al servidor:", formattedValues);
 
       await onSubmit(formattedValues);
       form.reset();
       onClose();
     } catch (error) {
+      console.error("Error al guardar:", error);
       toast({
         title: "Error al guardar",
         description:
@@ -234,6 +352,60 @@ const MuseumForm = ({
               )}
             />
 
+            {/* Campos de ubicación: latitud y longitud */}
+            <div className="grid grid-cols-2 gap-4">
+              <FormField
+                control={form.control}
+                name="latitude"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Latitud</FormLabel>
+                    <FormDescription className="text-xs text-gray-500">
+                      Valor entre -90 y 90
+                    </FormDescription>
+                    <FormControl>
+                      <Input
+                        type="number"
+                        step="0.000001"
+                        placeholder="Ej. 19.4326"
+                        value={field.value ?? ""}
+                        onChange={(e) => {
+                          const value = e.target.value;
+                          field.onChange(value === "" ? "" : parseFloat(value));
+                        }}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="longitude"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Longitud</FormLabel>
+                    <FormDescription className="text-xs text-gray-500">
+                      Valor entre -180 y 180
+                    </FormDescription>
+                    <FormControl>
+                      <Input
+                        type="number"
+                        step="0.000001"
+                        placeholder="Ej. -99.1332"
+                        value={field.value ?? ""}
+                        onChange={(e) => {
+                          const value = e.target.value;
+                          field.onChange(value === "" ? "" : parseFloat(value));
+                        }}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
             {initialValues && (
               <FormField
                 control={form.control}
@@ -241,30 +413,19 @@ const MuseumForm = ({
                 render={({ field }) => (
                   <FormItem>
                     <FormLabel>Recorrido Principal</FormLabel>
-                    <Select
-                      onValueChange={field.onChange}
-                      value={field.value || ""}
-                      disabled={!museumTours.length}
-                    >
-                      <FormControl>
-                        <SelectTrigger>
-                          <SelectValue
-                            placeholder={
-                              !museumTours.length
-                                ? "No hay recorridos disponibles"
-                                : "Seleccione un recorrido"
-                            }
-                          />
-                        </SelectTrigger>
-                      </FormControl>
-                      <SelectContent>
-                        {museumTours.map((tour) => (
-                          <SelectItem key={tour.id} value={tour.id}>
-                            {tour.name}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                    <FormControl>
+                      <CustomSelect
+                        value={field.value || ""}
+                        onChange={field.onChange}
+                        options={museumTours} // Pasar directamente los tours como options
+                        placeholder={
+                          !museumTours.length
+                            ? "No hay recorridos disponibles"
+                            : "Seleccione un recorrido"
+                        }
+                        error={!!form.formState.errors.main_tour_id}
+                      />
+                    </FormControl>
                     {!museumTours.length && (
                       <FormDescription>
                         <Link
@@ -284,38 +445,106 @@ const MuseumForm = ({
 
             {/* Horarios */}
             <div className="space-y-4">
-              <FormLabel>Horarios</FormLabel>
+              <div className="flex justify-between items-center">
+                <FormLabel>Horarios</FormLabel>
+                {hoursErrors.length > 0 && (
+                  <p className="text-xs text-destructive">
+                    Hay errores en los horarios
+                  </p>
+                )}
+              </div>
+              <div className="text-sm text-gray-500 mb-2">
+                Configura los horarios del museo. Si todos están cerrados, se
+                creará el museo sin horarios.
+              </div>
+
+              {/* Mostrar errores de horarios */}
+              {hoursErrors.length > 0 && (
+                <div className="bg-red-50 border border-red-200 rounded-md p-3 mb-4">
+                  <p className="text-sm font-medium text-red-800 mb-2">
+                    Por favor, corrija los siguientes errores:
+                  </p>
+                  <ul className="text-xs text-red-700 list-disc pl-5 space-y-1">
+                    {hoursErrors.map((error, index) => (
+                      <li key={index}>{error}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
 
               <div className="border divide-y rounded-md">
-                {museumHours.map((hour) => (
-                  <div
-                    key={hour.day}
-                    className="flex items-center justify-between p-3 hover:bg-gray-50"
-                  >
-                    <span className="font-medium text-gray-700">{hour.day}</span>
-                    <div className="flex items-center gap-3">
-                      <span className="text-gray-600">
-                        {hour.isOpen
-                          ? hour.openTime && hour.closeTime
-                            ? `${hour.openTime} - ${hour.closeTime}`
-                            : "Abierto 24h"
-                          : "Cerrado"}
-                      </span>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        className="w-8 h-8 p-0"
-                        onClick={() => {
-                          setHoursDialogOpen(true);
-                          setCurrentEditingDay(hour.day);
-                        }}
+                {museumHours.map((hour) => {
+                  const dayName =
+                    hour.day === "SUNDAY"
+                      ? "Domingo"
+                      : hour.day === "MONDAY"
+                      ? "Lunes"
+                      : hour.day === "TUESDAY"
+                      ? "Martes"
+                      : hour.day === "WEDNESDAY"
+                      ? "Miércoles"
+                      : hour.day === "THURSDAY"
+                      ? "Jueves"
+                      : hour.day === "FRIDAY"
+                      ? "Viernes"
+                      : hour.day === "SATURDAY"
+                      ? "Sábado"
+                      : hour.day;
+
+                  // Verificar si este día tiene errores
+                  const hasError = hoursErrors.some((error) =>
+                    error.startsWith(dayName)
+                  );
+
+                  return (
+                    <div
+                      key={hour.day}
+                      className={`flex items-center justify-between p-3 hover:bg-gray-50 ${
+                        hasError ? "bg-red-50" : ""
+                      }`}
+                    >
+                      <span
+                        className={`font-medium ${
+                          hasError ? "text-red-700" : "text-gray-700"
+                        }`}
                       >
-                        <Pencil className="w-4 h-4 text-gray-500" />
-                      </Button>
+                        {dayName}
+                      </span>
+                      <div className="flex items-center gap-3">
+                        <span
+                          className={
+                            hasError ? "text-red-600" : "text-gray-600"
+                          }
+                        >
+                          {hour.isOpen
+                            ? hour.openTime &&
+                              hour.closeTime &&
+                              (hour.openTime !== "00:00" ||
+                                hour.closeTime !== "23:59")
+                              ? `${hour.openTime} - ${hour.closeTime}`
+                              : "Abierto 24h"
+                            : "Cerrado"}
+                        </span>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          className="w-8 h-8 p-0"
+                          onClick={() => {
+                            setHoursDialogOpen(true);
+                            setCurrentEditingDay(hour.day);
+                          }}
+                        >
+                          <Pencil
+                            className={`w-4 h-4 ${
+                              hasError ? "text-red-500" : "text-gray-500"
+                            }`}
+                          />
+                        </Button>
+                      </div>
                     </div>
-                  </div>
-                ))}
+                  );
+                })}
               </div>
 
               <div className="flex flex-wrap gap-2">
@@ -342,6 +571,18 @@ const MuseumForm = ({
                   }}
                 >
                   Editar lun–vie
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="text-gray-700"
+                  onClick={() => {
+                    setHoursDialogOpen(true);
+                    setCurrentEditingDay("weekend");
+                  }}
+                >
+                  Editar sáb-dom
                 </Button>
               </div>
             </div>
@@ -407,6 +648,8 @@ const MuseumForm = ({
                 return updatedHour || hour;
               })
             );
+            // Validar horarios después de actualizarlos
+            setTimeout(() => validateHours(), 0);
             setHoursDialogOpen(false);
             setCurrentEditingDay(null);
           }}

--- a/src/pages/MuseumPage.tsx
+++ b/src/pages/MuseumPage.tsx
@@ -1,6 +1,6 @@
 import { Card } from "@/components/ui/card";
 import { getMuseumById } from "@/services/Museums";
-import { Museum } from "@/types/Museums";
+import { Museum, dayReverseMap } from "@/types/Museums";
 import { useCallback, useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { Clock, MapPin, DollarSign } from "lucide-react";
@@ -9,17 +9,193 @@ import { Button } from "@/components/ui/button";
 import MuseumStatus from "@/components/NowShowing/MuseumStatus";
 import { MuseumInfoCard } from "@/features/museum/componets/MuseumInfoCard";
 
+// Componente para mostrar los horarios del museo
+interface MuseumHourDisplayProps {
+  hours: {
+    day: string;
+    isOpen: boolean;
+    openTime?: string | null;
+    closeTime?: string | null;
+  }[];
+}
+
+// Tipo para los datos de días agrupados
+type DayGroup = {
+  days: string[];
+  schedule: string;
+};
+
+const MuseumHoursDisplay = ({ hours }: MuseumHourDisplayProps) => {
+  if (!hours || hours.length === 0) {
+    return <p className="text-black">Horario no disponible</p>;
+  }
+
+  // Ordenar los días según el orden tradicional (Lunes a Domingo para la visualización)
+  const orderedDayKeys = [
+    "MONDAY",
+    "TUESDAY",
+    "WEDNESDAY",
+    "THURSDAY",
+    "FRIDAY",
+    "SATURDAY",
+    "SUNDAY",
+  ];
+
+  // Función auxiliar para formatear hora y minutos
+  const formatTime = (time: string | null): string => {
+    if (!time) return "";
+    const [hours, minutes] = time.split(":");
+    const numHours = parseInt(hours);
+
+    // Formato 12h con a.m/p.m
+    const suffix = numHours >= 12 ? "p.m" : "a.m";
+    const displayHours = numHours % 12 || 12;
+
+    // Si los minutos son '00', mostrar solo la hora
+    if (minutes === "00") {
+      return `${displayHours} ${suffix}`;
+    } else {
+      return `${displayHours}:${minutes} ${suffix}`;
+    }
+  };
+
+  const sortedHours = [...hours].sort((a, b) => {
+    return orderedDayKeys.indexOf(a.day) - orderedDayKeys.indexOf(b.day);
+  });
+
+  // Función para obtener los grupos de días con horarios similares
+  const getDayGroups = (): DayGroup[] => {
+    const groups: DayGroup[] = [];
+
+    // Para agrupar días con el mismo horario
+    const scheduleMap: Record<string, string[]> = {};
+
+    // Procesar cada día
+    sortedHours.forEach((hour) => {
+      let scheduleKey = "";
+
+      if (!hour.isOpen) {
+        scheduleKey = "CLOSED";
+      } else if (!hour.openTime || !hour.closeTime) {
+        scheduleKey = "24H";
+      } else {
+        scheduleKey = `${hour.openTime}-${hour.closeTime}`;
+      }
+
+      if (!scheduleMap[scheduleKey]) {
+        scheduleMap[scheduleKey] = [];
+      }
+
+      scheduleMap[scheduleKey].push(hour.day);
+    });
+
+    // Convertir el mapa en grupos
+    Object.entries(scheduleMap).forEach(([key, days]) => {
+      // Ordenar los días según orderedDayKeys
+      days.sort(
+        (a, b) => orderedDayKeys.indexOf(a) - orderedDayKeys.indexOf(b)
+      );
+
+      // Determinar el texto del horario
+      let scheduleText = "";
+
+      if (key === "CLOSED") {
+        scheduleText = "Cerrado";
+      } else if (key === "24H") {
+        scheduleText = "Abierto 24h";
+      } else {
+        const [openTime, closeTime] = key.split("-");
+        scheduleText = `${formatTime(openTime)} - ${formatTime(closeTime)}`;
+      }
+
+      // Agrupar días consecutivos
+      const dayGroups: string[][] = [];
+      let currentGroup: string[] = [days[0]];
+
+      for (let i = 1; i < days.length; i++) {
+        const currentDay = days[i];
+        const prevDay = days[i - 1];
+
+        // Verificar si los días son consecutivos
+        if (
+          orderedDayKeys.indexOf(currentDay) ===
+          orderedDayKeys.indexOf(prevDay) + 1
+        ) {
+          currentGroup.push(currentDay);
+        } else {
+          dayGroups.push([...currentGroup]);
+          currentGroup = [currentDay];
+        }
+      }
+
+      if (currentGroup.length > 0) {
+        dayGroups.push(currentGroup);
+      }
+
+      // Crear grupo para cada conjunto de días consecutivos
+      dayGroups.forEach((groupDays) => {
+        groups.push({
+          days: groupDays,
+          schedule: scheduleText,
+        });
+      });
+    });
+
+    // Ordenar los grupos según el primer día de cada grupo
+    groups.sort((a, b) => {
+      return (
+        orderedDayKeys.indexOf(a.days[0]) - orderedDayKeys.indexOf(b.days[0])
+      );
+    });
+
+    return groups;
+  };
+
+  // Obtener los grupos de días
+  const dayGroups = getDayGroups();
+
+  // Formatear texto para rango de días
+  const formatDayRangeText = (days: string[]): string => {
+    if (days.length === 1) {
+      return `${dayReverseMap[days[0]]}:`;
+    } else {
+      return `${dayReverseMap[days[0]]} - ${
+        dayReverseMap[days[days.length - 1]]
+      }:`;
+    }
+  };
+
+  return (
+    <div className="text-black space-y-4">
+      {dayGroups.map((group, index) => (
+        <div key={index} className="flex flex-col">
+          <div className="font-bold">{formatDayRangeText(group.days)}</div>
+          <div>{group.schedule}</div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
 const MuseumPage = () => {
   // ----[ States ]----
   const [museum, setMuseum] = useState<Museum | null>(null);
+  const [loading, setLoading] = useState(true);
 
   // ----[ Hooks ]----
   const { id } = useParams<{ id: string }>();
 
   // ----[ Callbacks ]----
   const fetchMuseum = useCallback(async () => {
-    const museum = await getMuseumById(id as string);
-    setMuseum(museum);
+    try {
+      setLoading(true);
+      const museumData = await getMuseumById(id as string);
+      setMuseum(museumData);
+    } catch (error) {
+      console.error("Error al obtener datos del museo:", error);
+    } finally {
+      setLoading(false);
+    }
   }, [id]);
 
   // ----[ Effects ]----
@@ -27,7 +203,21 @@ const MuseumPage = () => {
     fetchMuseum();
   }, [fetchMuseum]);
 
-  if (!museum) return null;
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center h-screen">
+        Cargando...
+      </div>
+    );
+  }
+
+  if (!museum) {
+    return (
+      <div className="flex justify-center items-center h-screen">
+        Museo no encontrado
+      </div>
+    );
+  }
 
   return (
     <div className="w-full">
@@ -62,9 +252,13 @@ const MuseumPage = () => {
               title="Horarios"
               icon={<Clock className="w-6 h-6 text-white" />}
             >
-              <p className="text-sm text-muted-foreground">
-                Horario no disponible
-              </p>
+              {museum.hours && museum.hours.length > 0 ? (
+                <MuseumHoursDisplay hours={museum.hours} />
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  Horario no disponible
+                </p>
+              )}
             </MuseumInfoCard>
 
             {/* Ubicación */}
@@ -82,11 +276,24 @@ const MuseumPage = () => {
               title="Cuota de recuperación"
               icon={<DollarSign className="w-6 h-6 text-white" />}
             >
-              <p className="text-sm text-muted-foreground">
-                no disponible
-              </p>
+              <p className="text-sm text-muted-foreground">no disponible</p>
             </MuseumInfoCard>
           </div>
+
+          {/* Google Maps iframe */}
+          {museum.latitude && museum.longitude && (
+            <div className="mb-10 overflow-hidden border rounded-lg shadow-md">
+              <iframe
+                src={`https://www.google.com/maps/embed?pb=!1m14!1m12!1m3!1d500!2d${museum.longitude}!3d${museum.latitude}!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!5e0!3m2!1ses-419!2smx!4v1620000000000!5m2!1ses-419!2smx`}
+                width="100%"
+                height="400"
+                style={{ border: 0 }}
+                allowFullScreen={true}
+                loading="lazy"
+                title={`Ubicación de ${museum.name}`}
+              ></iframe>
+            </div>
+          )}
 
           <div className="flex justify-end mt-4">
             <MuseumStatus />
@@ -168,7 +375,7 @@ const MuseumPage = () => {
                     variant="default"
                     size="lg"
                     className="font-medium text-white rounded-xl"
-                    >
+                  >
                     Ayuda
                   </Button>
                 </div>
@@ -180,4 +387,5 @@ const MuseumPage = () => {
     </div>
   );
 };
+
 export default MuseumPage;

--- a/src/pages/admin/AdminMuseums.tsx
+++ b/src/pages/admin/AdminMuseums.tsx
@@ -8,10 +8,11 @@ import { createMuseum, deleteMuseum, editMuseum } from "@/services/Museums";
 import { useToast } from "@/hooks/use-toast";
 import MuseumForm from "@/features/admin/components/MuseumForm";
 import HoursDisplay from "@/features/admin/components/HoursDisplay";
-import { Clock } from "lucide-react";
+import { Clock, MapPin } from "lucide-react";
 import { MuseumHours } from "@/types/Museums";
 import { useFetchMuseums } from "@/features/admin/queries/useMuseumsQuery";
 import Loader from "@/shared/components/Loader";
+import { AxiosError } from "axios";
 
 const columns: ColumnDef<Museum>[] = [
   {
@@ -20,7 +21,7 @@ const columns: ColumnDef<Museum>[] = [
     cell: ({ row }) => {
       const photo = row.getValue("main_photo") as string;
       return <PhotoCellModal photo={photo} />;
-    }  
+    },
   },
   {
     accessorKey: "name",
@@ -32,8 +33,8 @@ const columns: ColumnDef<Museum>[] = [
         <Link to={`/museum/${id}`} className="text-blue-500 hover:underline">
           {name}
         </Link>
-      )
-    }
+      );
+    },
   },
   {
     accessorKey: "description",
@@ -42,6 +43,32 @@ const columns: ColumnDef<Museum>[] = [
   {
     accessorKey: "address_name",
     header: "Dirección",
+  },
+  {
+    accessorKey: "location",
+    header: "Ubicación",
+    cell: ({ row }) => {
+      const latitude = row.original.latitude;
+      const longitude = row.original.longitude;
+
+      if (!latitude || !longitude) {
+        return (
+          <div className="flex items-center gap-2 text-gray-500">
+            <MapPin className="w-4 h-4" />
+            <span>No especificada</span>
+          </div>
+        );
+      }
+
+      return (
+        <div className="flex items-center gap-2">
+          <MapPin className="w-4 h-4 text-blue-500" />
+          <span>
+            {latitude.toFixed(4)}, {longitude.toFixed(4)}
+          </span>
+        </div>
+      );
+    },
   },
   {
     accessorKey: "hours",
@@ -56,8 +83,8 @@ const columns: ColumnDef<Museum>[] = [
           <span>No especificado</span>
         </div>
       );
-    }
-  }
+    },
+  },
 ];
 
 const AdminMuseums = () => {
@@ -65,46 +92,76 @@ const AdminMuseums = () => {
   const { data: museums, isFetching, refetch } = useFetchMuseums();
   const { toast } = useToast();
   const [formVisible, setFormVisible] = useState(false);
-  const [initialValues, setInitialValues] = useState<Museum | undefined>(undefined);
+  const [initialValues, setInitialValues] = useState<Museum | undefined>(
+    undefined
+  );
 
-  const onSubmit = async (values: Partial<Omit<Museum, 'main_tour_id'> & { main_tour_id?: string | null }>) => {
-    // todo: mejorar esta parte para no repetir lo mismo
-    console.log(values);
+  const onSubmit = async (
+    values: Partial<
+      Omit<Museum, "main_tour_id"> & { main_tour_id?: string | null }
+    >
+  ) => {
+    console.log("Enviando datos:", values);
     try {
       if (initialValues) {
+        // Editar museo existente
         const response = await editMuseum(initialValues.id, values as Museum);
         if (response) {
-          setFormVisible(false);
-          setInitialValues(undefined);
-          refetch();
           toast({
             title: "¡Museo actualizado!",
             description: "El museo ha sido actualizado exitosamente.",
             variant: "default",
           });
-        }
-      } else {
-        const response = await createMuseum(values as Museum);
-        if (response) {
           setFormVisible(false);
           setInitialValues(undefined);
-          refetch();
+          // Recargar datos después de operación exitosa
+          setTimeout(() => {
+            refetch();
+          }, 500);
+        }
+      } else {
+        // Crear nuevo museo
+        const response = await createMuseum(values as Museum);
+        if (response) {
           toast({
             title: "¡Museo creado!",
             description: "El museo ha sido creado exitosamente.",
             variant: "default",
           });
+          setFormVisible(false);
+          setInitialValues(undefined);
+          // Recargar datos después de operación exitosa
+          setTimeout(() => {
+            refetch();
+          }, 500);
         }
       }
     } catch (error: unknown) {
-      console.error(error);
+      console.error("Error en operación:", error);
+
+      // Obtener mensaje de error más detallado
+      let errorMessage = "Hubo un error en la operación solicitada.";
+      if (error && typeof error === "object") {
+        // Check if it's an axios error with response data
+        const axiosError = error as AxiosError<{ message?: string }>;
+        if (
+          axiosError.response?.data &&
+          "message" in axiosError.response.data
+        ) {
+          const responseData = axiosError.response.data;
+          if (typeof responseData.message === "string") {
+            errorMessage = responseData.message;
+          }
+        }
+      }
+
       toast({
         title: "Error",
-        description: "Hubo un error en la operación solicitada.",
+        description: errorMessage,
         variant: "destructive",
       });
     }
-  }
+  };
 
   const onDelete = async (id: string) => {
     try {
@@ -123,12 +180,12 @@ const AdminMuseums = () => {
         variant: "destructive",
       });
     }
-  }
+  };
 
   const handleClose = () => {
     setFormVisible(false);
     setInitialValues(undefined);
-  }
+  };
 
   if (isFetching) {
     return <Loader />;
@@ -142,14 +199,15 @@ const AdminMuseums = () => {
             Gestión de Museos
           </h1>
           <p className="text-gray-600">
-            Administra y organiza la información de los museos en la aplicación de manera eficiente.
+            Administra y organiza la información de los museos en la aplicación
+            de manera eficiente.
           </p>
         </div>
 
         <div className="overflow-hidden bg-white rounded-lg">
-          <DataTable 
-            columns={columns} 
-            data={museums?.data} 
+          <DataTable
+            columns={columns}
+            data={museums?.data}
             canCreate
             createText="Crear nuevo museo"
             onCreate={() => setFormVisible(true)}
@@ -164,7 +222,7 @@ const AdminMuseums = () => {
         </div>
 
         {formVisible && (
-          <MuseumForm 
+          <MuseumForm
             isOpen={formVisible}
             onClose={handleClose}
             onSubmit={onSubmit}

--- a/src/querys/museum.querys.ts
+++ b/src/querys/museum.querys.ts
@@ -1,12 +1,36 @@
-import { getAllMuseums } from "@/services/Museums";
+import { getAllMuseums, getMuseumById } from "@/services/Museums";
 import { useQuery } from "@tanstack/react-query";
 
-const MUSEUMS_QUERY_KEY = "museums";
+// Keys para las consultas
+export const QUERY_KEYS = {
+  museums: "museums",
+  museum: "museum",
+};
 
-// ----------- Queries -----------
+/**
+ * Hook para obtener todos los museos
+ * @returns Consulta con la lista de museos
+ */
 export const useFetchMuseums = () => {
   return useQuery({
-    queryKey: [MUSEUMS_QUERY_KEY],
-    queryFn: getAllMuseums
-  })
-}
+    queryKey: [QUERY_KEYS.museums],
+    queryFn: getAllMuseums,
+    staleTime: 5 * 60 * 1000, // 5 minutos
+    refetchOnWindowFocus: false,
+  });
+};
+
+/**
+ * Hook para obtener un museo por ID
+ * @param id ID del museo
+ * @returns Consulta con los datos del museo
+ */
+export const useFetchMuseumById = (id: string | undefined) => {
+  return useQuery({
+    queryKey: [QUERY_KEYS.museum, id],
+    queryFn: () => (id ? getMuseumById(id) : Promise.reject("ID no válido")),
+    enabled: !!id, // Solo ejecutar si hay un ID
+    staleTime: 5 * 60 * 1000, // 5 minutos
+    refetchOnWindowFocus: false,
+  });
+};

--- a/src/services/Museums.ts
+++ b/src/services/Museums.ts
@@ -1,44 +1,254 @@
-import { Museum } from "@/types/Museums";
+import { Museum, MuseumHours } from "@/types/Museums";
 import ResponseData from "@/shared/types/response-data.types";
 import axios from "axios";
 
 const apiBaseUrl = import.meta.env.VITE_API_BASE_URL;
 
+// API Interfaces
+interface ApiOpenHour {
+  day: string;
+  is_open: boolean;
+  open_time: string | null;
+  close_time: string | null;
+  museum_id: string;
+}
+
+interface ApiHourFormat {
+  day: string;
+  isOpen: boolean;
+  openTime: string | null;
+  closeTime: string | null;
+}
+
+interface ApiMuseum extends Omit<Museum, "hours"> {
+  open_hours?: ApiOpenHour[];
+  hours?: MuseumHours[];
+}
+
 interface MuseumsResponse {
   ok: boolean;
   message: string;
-  data: Museum[];
+  data: ApiMuseum[];
 }
 
+/**
+ * Transforms API hours format to frontend format
+ */
+const transformHoursFromApi = (apiHours: ApiOpenHour[]): MuseumHours[] => {
+  if (!apiHours || !Array.isArray(apiHours)) return [];
 
-// ----[ Crud operations ]----
-export const getAllMuseums = async (): Promise<MuseumsResponse> => {
-  const response = await axios.get<MuseumsResponse>(`${apiBaseUrl}/museums`);
-  return response.data;
+  return apiHours.map((hour) => ({
+    day: hour.day,
+    isOpen: hour.is_open,
+    openTime: hour.open_time || undefined,
+    closeTime: hour.close_time || undefined,
+  }));
 };
 
+/**
+ * Transforms frontend hours format to API format
+ */
+const transformHoursToApi = (hours: MuseumHours[]): ApiHourFormat[] => {
+  if (!hours || !Array.isArray(hours)) return [];
+
+  return hours.map((hour) => ({
+    day: hour.day,
+    isOpen: hour.isOpen,
+    // For open days, set times appropriately
+    // For closed days, explicitly set to null
+    openTime: hour.isOpen ? hour.openTime || "00:00" : null,
+    closeTime: hour.isOpen ? hour.closeTime || "23:59" : null,
+  }));
+};
+
+/**
+ * Processes museum data from API to frontend format
+ */
+const processMuseumFromApi = (apiMuseum: ApiMuseum): Museum => {
+  let hours: MuseumHours[] = [];
+
+  // Process hours from either format the API might return
+  if (apiMuseum.hours && Array.isArray(apiMuseum.hours)) {
+    hours = apiMuseum.hours;
+  } else if (apiMuseum.open_hours && Array.isArray(apiMuseum.open_hours)) {
+    hours = transformHoursFromApi(apiMuseum.open_hours);
+  }
+
+  // Create a new object without open_hours
+  const museum = {
+    ...apiMuseum,
+    hours,
+  } as Museum;
+
+  // Use a temporary object to remove open_hours
+  const tempObj = { ...museum } as unknown as {
+    [key: string]: unknown;
+  };
+  delete tempObj.open_hours;
+
+  return tempObj as unknown as Museum;
+};
+
+/**
+ * Prepares museum data for API submission
+ */
+const prepareMuseumForApi = (museum: Museum): Record<string, unknown> => {
+  // Create a simple object for the API
+  const apiData: Record<string, unknown> = { ...museum };
+
+  // Always include hours in the expected format
+  if (museum.hours && Array.isArray(museum.hours)) {
+    apiData.hours = transformHoursToApi(museum.hours);
+  } else {
+    // If no hours provided, send an empty array
+    apiData.hours = [];
+  }
+
+  return apiData;
+};
+
+/**
+ * Gets all museums
+ */
+export const getAllMuseums = async (): Promise<MuseumsResponse> => {
+  try {
+    const response = await axios.get<MuseumsResponse>(`${apiBaseUrl}/museums`);
+
+    if (response.data && response.data.data) {
+      // Process each museum to ensure consistent format
+      const transformedData = response.data.data.map(processMuseumFromApi);
+      response.data.data = transformedData as unknown as ApiMuseum[];
+    }
+
+    return response.data;
+  } catch (error) {
+    console.error("Error fetching museums:", error);
+    throw error;
+  }
+};
+
+/**
+ * Creates a new museum
+ */
 export const createMuseum = async (museum: Museum): Promise<Museum> => {
-  const response = await axios.post(`${apiBaseUrl}/museums`, museum);
-  return response.data;
-}
+  try {
+    console.log("Creating museum with data:", museum);
 
-export const editMuseum = async (id: string, museum: Museum): Promise<Museum> => {
-  const response = await axios.patch(`${apiBaseUrl}/museums/${id}`, museum);
-  return response.data;
-}
+    // Prepare data in format expected by API
+    const apiData = prepareMuseumForApi(museum);
+    console.log("Prepared data for API:", apiData);
 
+    const response = await axios.post(`${apiBaseUrl}/museums`, apiData);
+
+    if (response.data && response.data.data) {
+      // Process response to ensure consistent format
+      const processedMuseum = processMuseumFromApi(response.data.data);
+
+      // If hours were submitted but not in the response, add them
+      if (
+        (!processedMuseum.hours || processedMuseum.hours.length === 0) &&
+        museum.hours &&
+        museum.hours.length > 0
+      ) {
+        processedMuseum.hours = museum.hours;
+      }
+
+      return processedMuseum;
+    }
+
+    return response.data.data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      console.error("API Error:", error.response.status, error.response.data);
+    }
+    throw error;
+  }
+};
+
+/**
+ * Edits an existing museum
+ */
+export const editMuseum = async (
+  id: string,
+  museum: Museum
+): Promise<Museum> => {
+  try {
+    console.log("Editing museum with data:", museum);
+
+    // Prepare data in format expected by API
+    const apiData = prepareMuseumForApi(museum);
+    console.log("Prepared data for API:", apiData);
+
+    const response = await axios.patch(`${apiBaseUrl}/museums/${id}`, apiData);
+
+    if (response.data && response.data.data) {
+      // Process response to ensure consistent format
+      const processedMuseum = processMuseumFromApi(response.data.data);
+
+      // If hours were submitted but not in the response, add them
+      if (
+        (!processedMuseum.hours || processedMuseum.hours.length === 0) &&
+        museum.hours &&
+        museum.hours.length > 0
+      ) {
+        processedMuseum.hours = museum.hours;
+      }
+
+      return processedMuseum;
+    }
+
+    return response.data.data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      console.error("API Error:", error.response.status, error.response.data);
+    }
+    throw error;
+  }
+};
+
+/**
+ * Deletes a museum
+ */
 export const deleteMuseum = async (id: string): Promise<void> => {
-  const response = await axios.delete(`${apiBaseUrl}/museums/${id}`);
-  return response.data;
-}
+  try {
+    const response = await axios.delete(`${apiBaseUrl}/museums/${id}`);
+    return response.data.data;
+  } catch (error) {
+    console.error("Error deleting museum:", error);
+    throw error;
+  }
+};
 
-// ----[ Sub resources ]----
-export const getMuseumTours = async (museumId: string): Promise<ResponseData> => {
-  const response = await axios.get(`${apiBaseUrl}/museums/${museumId}/tours`);
-  return response.data;
-}
+/**
+ * Gets the tours of a museum
+ */
+export const getMuseumTours = async (
+  museumId: string
+): Promise<ResponseData> => {
+  try {
+    const response = await axios.get(`${apiBaseUrl}/museums/${museumId}/tours`);
+    return response.data;
+  } catch (error) {
+    console.error("Error fetching museum tours:", error);
+    throw error;
+  }
+};
 
+/**
+ * Gets a museum by ID
+ */
 export const getMuseumById = async (id: string): Promise<Museum> => {
-  const response = (await axios.get(`${apiBaseUrl}/museums/${id}`)).data;
-  return response.data;
-}
+  try {
+    const response = await axios.get(`${apiBaseUrl}/museums/${id}`);
+
+    if (response.data && response.data.data) {
+      // Process museum to ensure consistent format
+      return processMuseumFromApi(response.data.data);
+    }
+
+    return response.data.data;
+  } catch (error) {
+    console.error("Error fetching museum by ID:", error);
+    throw error;
+  }
+};

--- a/src/shared/components/CustomSelect.tsx
+++ b/src/shared/components/CustomSelect.tsx
@@ -1,10 +1,10 @@
 import { ChevronDown } from "lucide-react";
-import { Museum } from "@/types/Museums";
 
+// Mantener la interfaz original para compatibilidad
 interface CustomSelectProps {
   value: string;
   onChange: (value: string) => void;
-  options: Museum[];
+  options: { id: string; name: string }[]; // Tipo simplificado que acepta Museum, Tour y otros objetos similares
   placeholder: string;
   error?: boolean;
 }

--- a/src/types/Museums.ts
+++ b/src/types/Museums.ts
@@ -4,7 +4,10 @@ export interface Museum {
   description: string;
   address_name: string;
   main_photo: string;
+  latitude?: number;
+  longitude?: number;
   main_tour_id: string;
+  hours?: MuseumHours[];
   created_at: string;
   updated_at: string;
 }
@@ -12,6 +15,27 @@ export interface Museum {
 export interface MuseumHours {
   day: string;
   isOpen: boolean;
-  openTime?: string;
-  closeTime?: string;
+  openTime?: string | null;
+  closeTime?: string | null;
 }
+
+// Mapeo entre nombres de día en español e inglés para la API
+export const dayMap = {
+  Domingo: "SUNDAY",
+  Lunes: "MONDAY",
+  Martes: "TUESDAY",
+  Miércoles: "WEDNESDAY",
+  Jueves: "THURSDAY",
+  Viernes: "FRIDAY",
+  Sábado: "SATURDAY",
+};
+
+export const dayReverseMap: Record<string, string> = {
+  SUNDAY: "Domingo",
+  MONDAY: "Lunes",
+  TUESDAY: "Martes",
+  WEDNESDAY: "Miércoles",
+  THURSDAY: "Jueves",
+  FRIDAY: "Viernes",
+  SATURDAY: "Sábado",
+};


### PR DESCRIPTION
## ¿Qué tipo de PR es este?
- [ ] Refactorización
- [x] Funcionalidad
- [ ] Corrección de error
- [ ] Optimización
- [ ] Actualización de documentación

## Descripción
Este PR implementa la gestión de horarios en el CRUD de museos dentro del panel de administración. Se han añadido campos para la gestión de ubicaciones (`address_name`, `latitude`, `longitude`) y se ha integrado un iframe de Google Maps para visualizar la ubicación en la vista detallada del museo en la MuseumPage. Se han creado componentes para administrar el horario semanal con opciones para establecer días abiertos, cerrados o con horario 24h.

## Recursos útiles
...

## Pruebas
1. Crear un nuevo museo e intentar configurar sus horarios:
   - Usar la opción 'Editar todos los horarios' para configurar todos los días rápidamente
   - Configurar días individuales con diferentes horarios
   - Probar la configuración de días con horario 24h

2. Editar un museo existente:
   - Modificar sus coordenadas y verificar que el mapa se actualice correctamente
   - Cambiar los horarios de algunos días y verificar que se guarden correctamente

3. Ver un museo:
   - Comprobar que los horarios se muestran correctamente en el formato adecuado
   - Verificar que el mapa muestra la ubicación correcta según las coordenadas

## Capturas de pantalla

Asi luce el panel de admin:

![image](https://github.com/user-attachments/assets/65535f7a-0fc8-415b-93c7-c58b799a1aad)

Asi luce la visualizacion de el horario:

![image](https://github.com/user-attachments/assets/e0fa70a9-d258-40ab-a847-5ed2e8cd24cb)

Asi luce en su Pagina cada museo:

![image](https://github.com/user-attachments/assets/c8dbf1b4-4726-4e98-92fa-6fb949421024)


