### PR TITLE
Refactor/admin dashboard

### DIFF
--- a/src/components/AppBar/AppBar.tsx
+++ b/src/components/AppBar/AppBar.tsx
@@ -11,7 +11,6 @@ import CartButton from "../../features/cart/components/CartButton";
 import NavLink from "./NavLink";
 import { LoginButton } from "../Auth/LoginButton";
 import { UserAvatar } from "../Auth/UserAvatar";
-import { LogoutButton } from "../Auth/LogoutButton";
 
 export default function AppBar() {
   const { t } = useTranslation();
@@ -46,21 +45,13 @@ export default function AppBar() {
               <NavLink href="/">{t("Home")}</NavLink>
               <NavLink href="#">{t("About Muvi")}</NavLink>
               <NavLink href="/faqs">{t("FAQs")}</NavLink>
-              <NavLink href="#">{t("Help")}</NavLink>
             </div>
 
             {/* Botones acciones */}
             <div className="flex gap-5">
               <CartButton />
               <LanguageSelector />
-              {isAuthenticated ? (
-                <div className="flex items-center gap-5">
-                  <UserAvatar />
-                  <LogoutButton />
-                </div>
-              ) : (
-                <LoginButton />
-              )}
+              {isAuthenticated ? <UserAvatar /> : <LoginButton />}
             </div>
           </div>
           <div className="flex items-center lg:hidden">
@@ -76,14 +67,7 @@ export default function AppBar() {
             <NavLink href="#">{t("Help")}</NavLink>
             <LanguageSelector />
             <div className="flex flex-col gap-1">
-              {isAuthenticated ? (
-                <>
-                  <UserAvatar />
-                  <LogoutButton />
-                </>
-              ) : (
-                <LoginButton />
-              )}
+              {isAuthenticated ? <UserAvatar /> : <LoginButton />}
             </div>
             <SocialMediaIcons
               containerClass="flex space-x-5 pb-4"

--- a/src/components/Auth/UserAvatar.tsx
+++ b/src/components/Auth/UserAvatar.tsx
@@ -1,12 +1,102 @@
 import { useAuth } from "@/hooks/useAuth";
+import { useState, useRef, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router-dom";
 import { RxAvatar } from "react-icons/rx";
+import { IoLogOutOutline } from "react-icons/io5";
+import { BsCart3 } from "react-icons/bs";
 
 export const UserAvatar = () => {
-  const { user } = useAuth();
+  const { user, logout } = useAuth();
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // Cerrar dropdown al hacer click fuera
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setIsDropdownOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
+
+  const handleLogout = () => {
+    setIsDropdownOpen(false);
+    logout();
+  };
+
+  const handleMyPurchases = () => {
+    setIsDropdownOpen(false);
+    navigate("/my-purchases"); // Ajusta la ruta según corresponda
+  };
+
   return (
-    <button className="flex items-center justify-center align-middle space-x-2 bg-white border border-gray-300 hover:bg-gray-200 text-gray-700 py-2 px-3 rounded-lg text-sm transition duration-300 shadow-sm">
-      <RxAvatar className="text-xl text-primary" />
-      <h4>{user?.display_name}</h4>
-    </button>
+    <div className="relative" ref={dropdownRef}>
+      <button
+        onClick={() => setIsDropdownOpen(!isDropdownOpen)}
+        className="flex items-center justify-center align-middle space-x-2 bg-white border border-gray-300 hover:bg-gray-200 text-gray-700 py-2 px-3 rounded-lg text-sm transition duration-300 shadow-sm"
+      >
+        <RxAvatar className="text-xl text-primary" />
+        <h4 className="max-w-32 truncate">{user?.display_name}</h4>
+        {/* Icono de flecha */}
+        <svg
+          className={`w-4 h-4 transition-transform ${
+            isDropdownOpen ? "rotate-180" : ""
+          }`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M19 9l-7 7-7-7"
+          />
+        </svg>
+      </button>
+
+      {/* Dropdown menu */}
+      {isDropdownOpen && (
+        <div className="absolute right-0 mt-2 w-64 bg-white rounded-lg shadow-lg border border-gray-200 z-50">
+          {/* Usuario info */}
+          <div className="px-4 py-3 border-b border-gray-100">
+            <p className="text-sm font-medium text-gray-900">
+              {user?.display_name}
+            </p>
+            <p className="text-xs text-gray-500 truncate">{user?.email}</p>
+          </div>
+
+          {/* Menu items */}
+          <div className="py-1">
+            <button
+              onClick={handleMyPurchases}
+              className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 transition-colors duration-200"
+            >
+              <BsCart3 className="mr-3 text-lg text-gray-600" />
+              <span>{t("My Purchases")}</span>
+            </button>
+
+            <button
+              onClick={handleLogout}
+              className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-red-50 hover:text-red-600 transition-colors duration-200"
+            >
+              <IoLogOutOutline className="mr-3 text-lg" />
+              <span>{t("Logout")}</span>
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
   );
 };

--- a/src/components/Auth/UserAvatar.tsx
+++ b/src/components/Auth/UserAvatar.tsx
@@ -37,7 +37,7 @@ export const UserAvatar = () => {
 
   const handleMyPurchases = () => {
     setIsDropdownOpen(false);
-    navigate("/my-purchases"); // Ajusta la ruta según corresponda
+    navigate("/my-purchases");
   };
 
   return (

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -58,14 +58,7 @@ export default function Footer() {
           </div>
 
           <div className='mt-8 py-4 border-t border-white/20'>
-            <div className='flex justify-between items-center'>
-              <div className='flex items-center gap-4'>
-                <img 
-                  src="/assets/images/identity/pleca2023.png" 
-                  alt="Pleca 2023"
-                  className="h-12"
-                />
-              </div>
+            <div className="flex items-center justify-center">              
               <div className='text-sm text-white/80'>
                 <p>© 2024, Museo Universitario Fernando del Paso. Todos los derechos reservados</p>
               </div>

--- a/src/components/SocialMediaIcons/SocialMediaIcons.tsx
+++ b/src/components/SocialMediaIcons/SocialMediaIcons.tsx
@@ -1,6 +1,6 @@
 import { ZoomInOnScroll } from '../animations/ZoomInOnScroll';
 import SocialMediaIcon from './SocialMediaIcon';
-import { FaFacebook, FaWhatsapp, FaInstagram } from 'react-icons/fa';
+import { FaFacebook, FaWhatsapp } from 'react-icons/fa';
 
 export default function SocialMediaIcons({ containerClass = "", iconClass = "" }) {
   return (
@@ -13,11 +13,6 @@ export default function SocialMediaIcons({ containerClass = "", iconClass = "" }
       <ZoomInOnScroll duration={.8} delay={.3}>
         <SocialMediaIcon href="https://www.whatsapp.com" ariaLabel="Whatsapp">
           <FaWhatsapp className={iconClass} />
-        </SocialMediaIcon>
-      </ZoomInOnScroll>
-      <ZoomInOnScroll duration={.8} delay={.6}>
-        <SocialMediaIcon href="https://www.instagram.com" ariaLabel="Instagram">
-          <FaInstagram className={iconClass} />
         </SocialMediaIcon>
       </ZoomInOnScroll>
     </div>

--- a/src/features/admin/AdminLayout.tsx
+++ b/src/features/admin/AdminLayout.tsx
@@ -1,7 +1,7 @@
 import { Outlet } from "react-router-dom";
 import { SidebarProvider } from "@/components/ui/sidebar";
 import { SidebarCustomTrigger } from "@/components/ui/sidebar/custom-trigger";
-import { Bell, Search } from "lucide-react";
+import { Search } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import {
@@ -35,17 +35,6 @@ const AdminLayout = () => {
             </div>
 
             <div className="flex items-center gap-2 sm:gap-6">
-              <Button
-                variant="ghost"
-                size="icon"
-                className="relative hidden sm:flex"
-              >
-                <Bell className="h-5 w-5" />
-                <span className="absolute -top-1 -right-1 h-4 w-4 rounded-full bg-red-500 text-[10px] text-white flex items-center justify-center">
-                  3
-                </span>
-              </Button>
-
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button

--- a/src/features/admin/AdminLayout.tsx
+++ b/src/features/admin/AdminLayout.tsx
@@ -57,9 +57,7 @@ const AdminLayout = () => {
                     </div>
                   </Button>
                 </DropdownMenuTrigger>
-                <DropdownMenuContent className="w-56" align="end">
-                  <DropdownMenuItem>Mi Perfil</DropdownMenuItem>
-                  <DropdownMenuItem>Configuración</DropdownMenuItem>
+                <DropdownMenuContent className="w-56 py-2" align="end">
                   <DropdownMenuItem
                     className="text-red-600 hover:bg-red-50 dark:hover:bg-red-950 hover:cursor-pointer"
                     onClick={() => logout()}

--- a/src/features/admin/constants/navigationItems.ts
+++ b/src/features/admin/constants/navigationItems.ts
@@ -1,4 +1,4 @@
-import { Home, User, ChartBar, Layout, HelpCircle } from "lucide-react";
+import { Home, Layout, HelpCircle } from "lucide-react";
 import { MdOutlineMuseum, MdTour } from "react-icons/md";
 
 export const navigationItems = [
@@ -6,11 +6,6 @@ export const navigationItems = [
     title: "Dashboard",
     icon: Home,
     url: "/admin",
-  },
-  {
-    title: "Usuarios",
-    icon: User,
-    url: "/admin/users",
   },
   {
     title: "Museos",
@@ -31,10 +26,5 @@ export const navigationItems = [
     title: "FAQs",
     icon: HelpCircle,
     url: "/admin/faqs",
-  },
-  {
-    title: "Estadísticas",
-    icon: ChartBar,
-    url: "/admin/stats",
   },
 ];

--- a/src/features/admin/constants/navigationItems.ts
+++ b/src/features/admin/constants/navigationItems.ts
@@ -13,7 +13,7 @@ export const navigationItems = [
     url: "/admin/museums",
   },
   {
-    title: "Recorridos",
+    title: "Tours",
     icon: MdTour,
     url: "/admin/tours",
   },

--- a/src/features/admin/routes/index.tsx
+++ b/src/features/admin/routes/index.tsx
@@ -1,30 +1,26 @@
 import AdminHome from "@/pages/admin/AdminHome";
 import AdminMuseums from "@/pages/admin/AdminMuseums";
-import AdminStatistics from "@/pages/admin/AdminStats";
 import AdminTours from "@/pages/admin/AdminTours";
-import AdminUsers from "@/pages/admin/AdminUsers";
 import LandingPage from "@/pages/admin/LandingPage";
 import AdminFaqs from "@/pages/admin/AdminFaqs";
 
 const adminRoutes = {
   children: [
     { path: "", element: <AdminHome /> },
-    { path: "users", element: <AdminUsers /> },
     {
       path: "museums",
       element: <AdminMuseums />,
     },
-    { path: "stats", element: <AdminStatistics /> },
     {
       path: "tours",
       element: <AdminTours />,
     },
     {
-      path: "/admin/landing",
+      path: "landing",
       element: <LandingPage />,
     },
     {
-      path: "/admin/faqs",
+      path: "faqs",
       element: <AdminFaqs />,
     },
   ],

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -1,6 +1,6 @@
 import { Outlet } from "react-router-dom";
 import AppBar from "../components/AppBar/AppBar";
-import Footer from "../components/Footer";
+import Footer from "../components/Footer/Footer";
 import CartCleaner from "../features/cart/components/CartCleaner";
 
 export default function AppLayout() {

--- a/src/layouts/NoAppBarLayout.tsx
+++ b/src/layouts/NoAppBarLayout.tsx
@@ -1,5 +1,5 @@
 import { Outlet } from "react-router-dom";
-import Footer from "../components/Footer";
+import Footer from "../components/Footer/Footer";
 
 export default function NoAppBarLayout() {
   return (

--- a/src/pages/MyPurchasesPage.tsx
+++ b/src/pages/MyPurchasesPage.tsx
@@ -1,0 +1,201 @@
+import { useAuth } from "@/hooks/useAuth";
+import { useFetchUserOrders, type Order } from "@/querys/orders.querys";
+import Loader from "@/shared/components/Loader";
+import { useTranslation } from "react-i18next";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Calendar, Package, CreditCard, Eye, ShoppingBag } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import { dateFormatter } from "@/utils/dateFormatter";
+import { timeFormatter } from "@/utils/timeFormatter";
+
+// Función helper para obtener el color del status
+const getStatusColor = (status: string) => {
+  switch (status.toLowerCase()) {
+    case "completed":
+      return "bg-green-100 text-green-800 border-green-200";
+    case "pending":
+      return "bg-yellow-100 text-yellow-800 border-yellow-200";
+    case "canceled":
+      return "bg-red-100 text-red-800 border-red-200";
+    default:
+      return "bg-gray-100 text-gray-800 border-gray-200";
+  }
+};
+
+// Función helper para traducir el status
+const getStatusText = (status: string, t: (key: string) => string) => {
+  switch (status.toLowerCase()) {
+    case "completed":
+      return t("Completed");
+    case "pending":
+      return t("Pending");
+    case "canceled":
+      return t("Canceled");
+    default:
+      return status;
+  }
+};
+
+// Componente para mostrar una orden individual
+const OrderCard = ({ order }: { order: Order }) => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  const handleViewDetails = () => {
+    navigate(`/orders/${order.id}`);
+  };
+
+  return (
+    <Card className="hover:shadow-lg transition-shadow duration-300">
+      <CardHeader className="pb-4">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-lg flex items-center gap-2">
+            <Package className="h-5 w-5 text-primary" />
+            {t("Order")} #{order.id.slice(-8)}
+          </CardTitle>
+          <Badge className={getStatusColor(order.status)}>
+            {getStatusText(order.status, t)}
+          </Badge>
+        </div>
+      </CardHeader>
+
+      <CardContent className="space-y-4">
+        {/* Información de la orden */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="flex items-center gap-2 text-sm text-gray-600">
+            <Calendar className="h-4 w-4" />
+            <span>
+              {dateFormatter(order.created_at)} a las{" "}
+              {timeFormatter(order.created_at)}
+            </span>
+          </div>
+          <div className="flex items-center gap-2 text-sm text-gray-600">
+            <CreditCard className="h-4 w-4" />
+            <span className="font-semibold">${order.total}</span>
+          </div>
+        </div>
+
+        {/* Tours incluidos */}
+        <div>
+          <h4 className="font-semibold mb-2 text-sm text-gray-700">
+            {t("Tours included")} ({order.tours.length})
+          </h4>
+          <div className="space-y-2">
+            {order.tours.slice(0, 2).map((tour) => (
+              <div
+                key={tour.id}
+                className="flex items-center gap-3 p-2 bg-gray-50 rounded-lg"
+              >
+                {tour.image_url && (
+                  <img
+                    src={tour.image_url}
+                    alt={tour.name}
+                    className="w-12 h-12 object-cover rounded-md"
+                  />
+                )}
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-gray-900 truncate">
+                    {tour.name}
+                  </p>
+                  <p className="text-xs text-gray-600">${tour.price}</p>
+                </div>
+              </div>
+            ))}
+            {order.tours.length > 2 && (
+              <p className="text-xs text-gray-500 pl-2">
+                {t("And {{count}} more...", { count: order.tours.length - 2 })}
+              </p>
+            )}
+          </div>
+        </div>
+
+        {/* Botón para ver detalles */}
+        <Button
+          onClick={handleViewDetails}
+          variant="outline"
+          className="w-full mt-4"
+        >
+          <Eye className="h-4 w-4 mr-2" />
+          {t("View Details")}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+};
+
+// Componente principal de la página
+const MyPurchasesPage = () => {
+  const { t } = useTranslation();
+  const { user } = useAuth();
+  const {
+    data: ordersResponse,
+    isLoading,
+    error,
+  } = useFetchUserOrders(user?.id || "", !!user?.id);
+
+  if (isLoading) {
+    return (
+      <div className="container mx-auto px-4 py-8 flex justify-center items-center min-h-[400px]">
+        <Loader />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold text-gray-900 mb-4">
+            {t("Error")}
+          </h1>
+          <p className="text-gray-600">
+            {t("There was an error loading your purchases")}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const orders = ordersResponse?.data || [];
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      {/* Header */}
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold text-gray-900 mb-2 flex items-center gap-3">
+          <ShoppingBag className="h-8 w-8 text-primary" />
+          {t("My Purchases")}
+        </h1>
+        <p className="text-gray-600">
+          {t("Here you can see all your tour purchases and their status")}
+        </p>
+      </div>
+
+      {/* Lista de órdenes */}
+      {orders.length === 0 ? (
+        <div className="text-center py-12">
+          <ShoppingBag className="h-24 w-24 text-gray-300 mx-auto mb-4" />
+          <h2 className="text-xl font-semibold text-gray-700 mb-2">
+            {t("No purchases yet")}
+          </h2>
+          <p className="text-gray-500 mb-6">
+            {t("When you make your first purchase, it will appear here")}
+          </p>
+          <Button onClick={() => (window.location.href = "/tours")}>
+            {t("Explore Tours")}
+          </Button>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          {orders.map((order) => (
+            <OrderCard key={order.id} order={order} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MyPurchasesPage;

--- a/src/pages/admin/AdminHome.tsx
+++ b/src/pages/admin/AdminHome.tsx
@@ -1,10 +1,263 @@
+import { useNavigate } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { Building, Route, Image, HelpCircle, ChevronRight } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import Loader from "@/shared/components/Loader";
+import { getAllMuseums } from "@/services/Museums";
+import { getAllTours } from "@/services/tour.services";
+import { getAllFaqs } from "@/services/Faqs";
+import { getMainCarousel } from "@/services/Carousel";
 
-const AdminHome = () => {
-  return (
-    <div>
-      <h1>Admin Principal</h1>
-    </div>
-  )
+// Definición de las rutas de administración
+const adminRoutes = [
+  {
+    id: "museums",
+    path: "/admin/museums",
+    title: "Gestión de Museos",
+    description:
+      "Administra museos, horarios, direcciones y ubicaciones en el mapa",
+    icon: Building,
+    color: "text-blue-600",
+    bgColor: "bg-blue-50",
+    features: [
+      "Crear y editar museos",
+      "Gestionar horarios",
+      "Ubicaciones GPS",
+      "Información de contacto",
+    ],
+  },
+  {
+    id: "tours",
+    path: "/admin/tours",
+    title: "Gestión de Tours",
+    description: "Administra tours, precios, calificaciones y etiquetas",
+    icon: Route,
+    color: "text-green-600",
+    bgColor: "bg-green-50",
+    features: [
+      "Crear nuevos tours",
+      "Establecer precios",
+      "Gestionar tags",
+      "Calificaciones",
+    ],
+  },
+  {
+    id: "faqs",
+    path: "/admin/faqs",
+    title: "Preguntas Frecuentes",
+    description: "Gestiona preguntas y respuestas para los usuarios",
+    icon: HelpCircle,
+    color: "text-purple-600",
+    bgColor: "bg-purple-50",
+    features: [
+      "Crear preguntas",
+      "Editar respuestas",
+      "Organizar contenido",
+      "Soporte usuarios",
+    ],
+  },
+  {
+    id: "landing",
+    path: "/admin/landing",
+    title: "Landing Page",
+    description:
+      "Administra el carrusel principal y contenido de la página inicial",
+    icon: Image,
+    color: "text-orange-600",
+    bgColor: "bg-orange-50",
+    features: [
+      "Carrusel principal",
+      "Vista previa",
+      "Gestión de slides",
+      "Contenido multimedia",
+    ],
+  },
+];
+
+interface Stats {
+  museums: number;
+  tours: number;
+  faqs: number;
+  carouselSlides: number;
 }
 
-export default AdminHome
+const AdminHome = () => {
+  const navigate = useNavigate();
+  const [stats, setStats] = useState<Stats>({
+    museums: 0,
+    tours: 0,
+    faqs: 0,
+    carouselSlides: 0,
+  });
+  const [loading, setLoading] = useState(true);
+
+  // Función para cargar todas las estadísticas
+  const loadStats = async () => {
+    try {
+      setLoading(true);
+
+      // Cargar todas las estadísticas en paralelo
+      const [museumsRes, toursRes, faqsRes, carouselRes] = await Promise.all([
+        getAllMuseums(),
+        getAllTours(),
+        getAllFaqs(),
+        getMainCarousel(),
+      ]);
+
+      setStats({
+        museums: museumsRes.data?.length || 0,
+        tours: toursRes.data?.length || 0,
+        faqs: faqsRes.data?.length || 0,
+        carouselSlides: carouselRes.data?.slides?.length || 0,
+      });
+    } catch (error) {
+      console.error("Error loading stats:", error);
+      // En caso de error, mantener los valores en 0
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadStats();
+  }, []);
+
+  // Definir las estadísticas usando los datos reales
+  const statsData = [
+    {
+      label: "Total Museos",
+      value: stats.museums.toString(),
+      icon: Building,
+      iconColor: "text-blue-600",
+    },
+    {
+      label: "Tours Activos",
+      value: stats.tours.toString(),
+      icon: Route,
+      iconColor: "text-green-600",
+    },
+    {
+      label: "FAQs Disponibles",
+      value: stats.faqs.toString(),
+      icon: HelpCircle,
+      iconColor: "text-purple-600",
+    },
+    {
+      label: "Slides en Carrusel",
+      value: stats.carouselSlides.toString(),
+      icon: Image,
+      iconColor: "text-orange-600",
+    },
+  ];
+
+  if (loading) {
+    return (
+      <div className="container mx-auto py-8 px-6 flex justify-center items-center min-h-[400px]">
+        <Loader />
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto py-8 px-6">
+      {/* Header Principal */}
+      <div className="mb-8">
+        <h1 className="text-4xl font-bold text-gray-900 mb-2">
+          Panel de Administración
+        </h1>
+        <p className="text-gray-600 text-lg">
+          Gestiona todos los aspectos de tu plataforma de museos
+        </p>
+      </div>
+
+      {/* Estadísticas Rápidas */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
+        {statsData.map((stat, index) => {
+          const route = adminRoutes[index];
+          return (
+            <Card
+              key={index}
+              className="border-l-4 border-l-transparent hover:border-l-current transition-all duration-300 cursor-pointer hover:shadow-lg"
+              onClick={() => navigate(route.path)}
+            >
+              <CardContent className="pt-6">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm font-medium text-gray-600">
+                      {stat.label}
+                    </p>
+                    <p className="text-3xl font-bold text-gray-900 mt-1">
+                      {stat.value}
+                    </p>
+                  </div>
+                  <stat.icon className={`h-8 w-8 ${stat.iconColor}`} />
+                </div>
+                <div className="mt-3 text-right">
+                  <ChevronRight className="h-4 w-4 text-gray-400 ml-auto" />
+                </div>
+              </CardContent>
+            </Card>
+          );
+        })}
+      </div>
+
+      {/* Cards de Navegación */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+        {adminRoutes.map((route) => (
+          <Card
+            key={route.id}
+            className="group hover:shadow-lg transition-all duration-300 cursor-pointer border-0 shadow-md"
+            onClick={() => navigate(route.path)}
+          >
+            <CardHeader className={`${route.bgColor} rounded-t-lg`}>
+              <div className="flex items-center justify-between">
+                <div className="flex items-center space-x-3">
+                  <div className="p-2 bg-white rounded-lg">
+                    <route.icon className={`h-6 w-6 ${route.color}`} />
+                  </div>
+                  <div>
+                    <CardTitle className="text-xl">{route.title}</CardTitle>
+                    <CardDescription className="text-gray-700 mt-1">
+                      {route.description}
+                    </CardDescription>
+                  </div>
+                </div>
+                <ChevronRight className="h-5 w-5 text-gray-400 group-hover:text-gray-600 transition-colors" />
+              </div>
+            </CardHeader>
+            <CardContent className="pt-6">
+              <div className="space-y-2">
+                {route.features.map((feature, index) => (
+                  <div key={index} className="flex items-center space-x-2">
+                    <div className="h-1.5 w-1.5 bg-gray-400 rounded-full"></div>
+                    <p className="text-sm text-gray-600">{feature}</p>
+                  </div>
+                ))}
+              </div>
+              <Button
+                className="w-full mt-4 group-hover:bg-primary group-hover:text-white transition-all duration-300"
+                variant="outline"
+              >
+                Acceder <ChevronRight className="h-4 w-4 ml-2" />
+              </Button>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* Footer con información adicional */}
+      <div className="mt-8 text-center text-gray-500">
+        <p className="text-sm">Panel de Administración - Gestión de Museos</p>
+      </div>
+    </div>
+  );
+};
+
+export default AdminHome;

--- a/src/pages/admin/AdminStats.tsx
+++ b/src/pages/admin/AdminStats.tsx
@@ -1,9 +1,0 @@
-const AdminStatistics = () => {
-  return (
-    <div>
-      <h1>Admin Estadísticas</h1>
-    </div>
-  )
-}
-
-export default AdminStatistics

--- a/src/pages/admin/AdminUsers.tsx
+++ b/src/pages/admin/AdminUsers.tsx
@@ -1,9 +1,0 @@
-const AdminUsers = () => {
-  return (
-    <div>
-      <h1>Administrar Usuarios</h1>
-    </div>
-  )
-}
-
-export default AdminUsers

--- a/src/querys/orders.querys.ts
+++ b/src/querys/orders.querys.ts
@@ -1,0 +1,50 @@
+import { useQuery } from "@tanstack/react-query";
+import { getOneOrderById } from "@/services/orders.services";
+import { Tour } from "@/shared/types/Tour";
+import axios from "axios";
+import { getAuthConfig } from "@/services/preference.services";
+import { ResponseDataTyped } from "@/shared/types/response-data.types";
+
+export interface Order {
+  id: string;
+  total: number;
+  status: string;
+  user_id: string;
+  created_at: string;
+  updated_at: string;
+  completed_at: string;
+  canceled_at: string;
+  tours: Tour[];
+}
+
+const BASE_URL = import.meta.env.VITE_API_BASE_URL as string;
+const ORDERS_QUERY_KEY = "orders";
+
+// Service para obtener órdenes por usuario
+export const getOrdersByUser = async (
+  userId: string
+): Promise<ResponseDataTyped<Order[]>> => {
+  const response = await axios.get<ResponseDataTyped<Order[]>>(
+    `${BASE_URL}/orders/by-user/${userId}`,
+    getAuthConfig()
+  );
+  return response.data;
+};
+
+// Query para obtener todas las órdenes del usuario autenticado
+export const useFetchUserOrders = (userId: string, enabled = true) => {
+  return useQuery({
+    queryKey: [ORDERS_QUERY_KEY, "by-user", userId],
+    queryFn: () => getOrdersByUser(userId),
+    enabled: !!userId && enabled,
+  });
+};
+
+// Query para obtener una orden específica por ID
+export const useFetchOrderById = (orderId: string, enabled = true) => {
+  return useQuery({
+    queryKey: [ORDERS_QUERY_KEY, "by-id", orderId],
+    queryFn: () => getOneOrderById(orderId),
+    enabled: !!orderId && enabled,
+  });
+};

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,6 +1,5 @@
 import { createBrowserRouter } from "react-router-dom";
 import { ProtectedRoute } from "@/components/ProtectedRoute/ProtectedRoute";
-
 import HomePage from "../pages/Home";
 import TourPage from "../pages/TourPage";
 import AppLayout from "../layouts/AppLayout";
@@ -17,6 +16,7 @@ import { ErrorBoundary } from "@/components/Errors/ErrorBoundary";
 import MuseumPage from "@/pages/MuseumPage";
 import { OrderDetailPage } from "@/pages/OrderDetailPage";
 import FaqsPage from "@/pages/FaqsPage";
+import MyPurchasesPage from "@/pages/MyPurchasesPage";
 
 const router = createBrowserRouter([
   {
@@ -57,6 +57,14 @@ const router = createBrowserRouter([
         element: (
           <ProtectedRoute>
             <CheckoutPage />
+          </ProtectedRoute>
+        ),
+      },
+      {
+        path: "/my-purchases",
+        element: (
+          <ProtectedRoute>
+            <MyPurchasesPage />
           </ProtectedRoute>
         ),
       },

--- a/src/translate/translations_en.ts
+++ b/src/translate/translations_en.ts
@@ -7,6 +7,7 @@ export const en = {
         "Change language": "Change language",
         "Login": "Login",
         "Logout": "Logout",
+        "My Purchases": "My Purchases",
         "help": {
             "title": "How can we help you?",
             "searchPlaceholder": "What's your question?",

--- a/src/translate/translations_en.ts
+++ b/src/translate/translations_en.ts
@@ -1,20 +1,53 @@
 export const en = {
-    translation: {
-        "Home": "Home",
-        "About Muvi": "About Muvi",
-        "Help": "Help",
-        "FAQs": "FAQs",
-        "Change language": "Change language",
-        "Login": "Login",
-        "Logout": "Logout",
-        "My Purchases": "My Purchases",
-        "help": {
-            "title": "How can we help you?",
-            "searchPlaceholder": "What's your question?",
-            "suggestedQuestions": "Questions that might help you",
-            "frequentQuestions": "Frequently asked questions",
-            "noResultsTitle": "No results found",
-            "noResultsMessage": "We couldn't find any questions matching your search. Please try with another keyword."
-        }
-    }
-}
+  translation: {
+    Home: "Home",
+    "About Muvi": "About Muvi",
+    Help: "Help",
+    FAQs: "FAQs",
+    "Change language": "Change language",
+    Login: "Login",
+    Logout: "Logout",
+    "My Purchases": "My Purchases",
+    help: {
+      title: "How can we help you?",
+      searchPlaceholder: "What's your question?",
+      suggestedQuestions: "Questions that might help you",
+      frequentQuestions: "Frequently asked questions",
+      noResultsTitle: "No results found",
+      noResultsMessage:
+        "We couldn't find any questions matching your search. Please try with another keyword.",
+    },
+
+    // My Purchases Page
+    Order: "Order",
+    Completed: "Completed",
+    Pending: "Pending",
+    Canceled: "Canceled",
+    "Tours included": "Tours included",
+    "And {{count}} more...": "And {{count}} more...",
+    "View Details": "View Details",
+    Error: "Error",
+    "There was an error loading your purchases":
+      "There was an error loading your purchases",
+    "Here you can see all your tour purchases and their status":
+      "Here you can see all your tour purchases and their status",
+    "No purchases yet": "No purchases yet",
+    "When you make your first purchase, it will appear here":
+      "When you make your first purchase, it will appear here",
+    "Explore Tours": "Explore Tours",
+
+    // Order statuses
+    Processing: "Processing",
+    Shipped: "Shipped",
+    Delivered: "Delivered",
+    Refunded: "Refunded",
+
+    // Additional related translations
+    "Order Date": "Order Date",
+    "Order Total": "Order Total",
+    "Show more tours": "Show more tours",
+    "Show less tours": "Show less tours",
+    "Go to order details": "Go to order details",
+    "Back to purchases": "Back to purchases",
+  },
+};

--- a/src/translate/translations_es.ts
+++ b/src/translate/translations_es.ts
@@ -7,6 +7,7 @@ export const es = {
         "Change language": "Cambiar idioma",
         "Login": "Iniciar sesión",
         "Logout": "Cerrar sesión",
+        "My Purchases": "Mis Compras",
         "help": {
             "title": "¿En qué te podemos ayudar?",
             "searchPlaceholder": "¿Cuál es tu duda?",

--- a/src/translate/translations_es.ts
+++ b/src/translate/translations_es.ts
@@ -1,20 +1,53 @@
 export const es = {
-    translation: {
-        "Home": "Inicio",
-        "About Muvi": "Acerca de Muvi",
-        "Help": "Ayuda",
-        "FAQs": "Preguntas Frecuentes",
-        "Change language": "Cambiar idioma",
-        "Login": "Iniciar sesión",
-        "Logout": "Cerrar sesión",
-        "My Purchases": "Mis Compras",
-        "help": {
-            "title": "¿En qué te podemos ayudar?",
-            "searchPlaceholder": "¿Cuál es tu duda?",
-            "suggestedQuestions": "Preguntas que te pueden ayudar",
-            "frequentQuestions": "Preguntas frecuentes",
-            "noResultsTitle": "No se encontraron resultados",
-            "noResultsMessage": "No encontramos preguntas que coincidan con tu búsqueda. Por favor, intenta con otra palabra clave."
-        }
-    }
-}
+  translation: {
+    Home: "Inicio",
+    "About Muvi": "Acerca de Muvi",
+    Help: "Ayuda",
+    FAQs: "Preguntas Frecuentes",
+    "Change language": "Cambiar idioma",
+    Login: "Iniciar sesión",
+    Logout: "Cerrar sesión",
+    "My Purchases": "Mis Compras",
+    help: {
+      title: "¿En qué te podemos ayudar?",
+      searchPlaceholder: "¿Cuál es tu duda?",
+      suggestedQuestions: "Preguntas que te pueden ayudar",
+      frequentQuestions: "Preguntas frecuentes",
+      noResultsTitle: "No se encontraron resultados",
+      noResultsMessage:
+        "No encontramos preguntas que coincidan con tu búsqueda. Por favor, intenta con otra palabra clave.",
+    },
+
+    // My Purchases Page
+    Order: "Orden",
+    Completed: "Completado",
+    Pending: "Pendiente",
+    Canceled: "Cancelado",
+    "Tours included": "Tours incluidos",
+    "And {{count}} more...": "Y {{count}} más...",
+    "View Details": "Ver Detalles",
+    Error: "Error",
+    "There was an error loading your purchases":
+      "Hubo un error al cargar tus compras",
+    "Here you can see all your tour purchases and their status":
+      "Aquí puedes ver todas tus compras de tours y su estado",
+    "No purchases yet": "Aún no hay compras",
+    "When you make your first purchase, it will appear here":
+      "Cuando hagas tu primera compra, aparecerá aquí",
+    "Explore Tours": "Explorar Tours",
+
+    // Order statuses
+    Processing: "Procesando",
+    Shipped: "Enviado",
+    Delivered: "Entregado",
+    Refunded: "Reembolsado",
+
+    // Additional related translations
+    "Order Date": "Fecha de Orden",
+    "Order Total": "Total de la Orden",
+    "Show more tours": "Mostrar más tours",
+    "Show less tours": "Mostrar menos tours",
+    "Go to order details": "Ir a detalles de la orden",
+    "Back to purchases": "Volver a compras",
+  },
+};


### PR DESCRIPTION
## ¿Qué tipo de PR es este?
- [x] Funcionalidad
- [ ] Refactorización
- [ ] Corrección de error
- [ ] Optimización
- [ ] Actualización de documentación

## Descripción
Implementé un dashboard administrativo moderno y funcional para `AdminHome` que incluye:

- **Panel principal con estadísticas en tiempo real**: Se conecta a las APIs existentes para mostrar conteos actualizados de museos, tours, FAQs y slides del carrusel
- **Navegación intuitiva**: Todas las cards (tanto estadísticas como principales) redirigen a sus respectivas páginas de administración
- **Integración con servicios existentes**: Utiliza `getAllMuseums()`, `getAllTours()`, `getAllFaqs()` y `getMainCarousel()` para obtener datos reales
- **Estado de carga**: Muestra un loader mientras se cargan las estadísticas
- **Diseño responsivo**: Compatible con móviles, tablets y desktop usando shadcn/ui y Tailwind CSS

## Recursos útiles
- **Servicios utilizados**:
  - `src/services/Museums.ts` - Para obtener listado de museos
  - `src/services/tour.services.ts` - Para obtener tours activos
  - `src/services/Faqs.ts` - Para obtener FAQs disponibles
  - `src/services/Carousel.ts` - Para obtener slides del carrusel principal

- **Componentes reutilizados**:
  - `Card`, `CardContent`, `CardHeader` de shadcn/ui
  - `Loader` component para estados de carga
  - Iconos de `lucide-react`

## Pruebas
Para probar la funcionalidad:

1. **Navegación**: Accede a `/admin` y verifica que:
   - Las 4 cards de estadísticas son clicables y redirigen correctamente
   - Las 4 cards principales también navegan a sus respectivas páginas
   - Los contadores muestran números reales (no hardcodeados)

2. **Estados de carga**: Recargar la página y observar:
   - El componente `Loader` aparece mientras se cargan las estadísticas
   - Las estadísticas se actualizan una vez cargados los datos

3. **Responsividad**: Verificar en diferentes tamaños de pantalla:
   - Mobile: Cards apiladas verticalmente
   - Tablet: Grid de 2 columnas para estadísticas
   - Desktop: Grid de 4 columnas para estadísticas completas

## Capturas de pantalla
![image](https://github.com/user-attachments/assets/29b2b318-df42-4594-8007-da4d5211c481)


**Características visuales aplicadas:**
- Efectos hover suaves en todas las cards
- Iconos representativos para cada sección
- Colores distintivos por categoría (azul para museos, verde para tours, etc.)
- Transiciones CSS para mejor UX